### PR TITLE
mise-à-jour de la dépendance à whitenoise

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -10,7 +10,7 @@ requests = "~=2.31.0"
 django-weasyprint = "~=2.2.0"
 psycopg2 = "~=2.9.5"
 dj-database-url = "~=2.1.0"
-whitenoise = "~=6.5.0"
+whitenoise = "~=6.6.0"
 sentry-sdk = "~=1.31.0"
 django-vite = "~=2.1.3"
 django-anymail = {extras = ["sendinblue"], version = "~=10.1"}

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "bcd4941c2c68468ebb1c42e258a5f714a061092a36095441ec0c935f6ef292d8"
+            "sha256": "3970c715f1568f07d40e522cdbbd0fee14a1aee8410f2d32e78aa79cec293b31"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -641,12 +641,12 @@
         },
         "whitenoise": {
             "hashes": [
-                "sha256:15fe60546ac975b58e357ccaeb165a4ca2d0ab697e48450b8f0307ca368195a8",
-                "sha256:16468e9ad2189f09f4a8c635a9031cc9bb2cdbc8e5e53365407acf99f7ade9ec"
+                "sha256:8998f7370973447fac1e8ef6e8ded2c5209a7b1f67c1012866dbcd09681c3251",
+                "sha256:b1f9db9bf67dc183484d760b99f4080185633136a273a03f6436034a41064146"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.7'",
-            "version": "==6.5.0"
+            "markers": "python_version >= '3.8'",
+            "version": "==6.6.0"
         },
         "zopfli": {
             "hashes": [


### PR DESCRIPTION
La version 6.6.0 est compatible avec Django 5.0.