### PR TITLE
ajout d'un paramètre mtm_campaign pour recherche-entreprises

### DIFF
--- a/impact/api/recherche_entreprises.py
+++ b/impact/api/recherche_entreprises.py
@@ -20,7 +20,7 @@ RECHERCHE_ENTREPRISE_TIMEOUT = 10
 def recherche(siren):
     # documentation api recherche d'entreprises 1.0.0 https://api.gouv.fr/documentation/api-recherche-entreprises
     try:
-        url = f"https://recherche-entreprises.api.gouv.fr/search?q={siren}&page=1&per_page=1"
+        url = f"https://recherche-entreprises.api.gouv.fr/search?q={siren}&page=1&per_page=1&mtm_campaign=portail-rse"
         response = requests.get(url, timeout=RECHERCHE_ENTREPRISE_TIMEOUT)
     except Exception as e:
         with sentry_sdk.push_scope() as scope:

--- a/impact/api/tests/test_recherche_entreprises.py
+++ b/impact/api/tests/test_recherche_entreprises.py
@@ -54,7 +54,7 @@ def test_succes_recherche_comportant_la_raison_sociale(mocker):
         "code_pays_etranger_sirene": 99139,
     }
     faked_request.assert_called_once_with(
-        f"https://recherche-entreprises.api.gouv.fr/search?q={SIREN}&page=1&per_page=1",
+        f"https://recherche-entreprises.api.gouv.fr/search?q={SIREN}&page=1&per_page=1&mtm_campaign=portail-rse",
         timeout=RECHERCHE_ENTREPRISE_TIMEOUT,
     )
 


### PR DESCRIPTION
Les mainteneurs de l'API recherche-entreprises souhaitent mieux connaitre l'origine des requêtes (cf. https://github.com/betagouv/portail-rse/issues/90).