### PR TITLE
désactivation des tests réseau dans l'intégration continue

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,4 +41,4 @@ jobs:
     - name: Install dependencies
       run: pipenv install -d
     - name: Run tests
-      run: pipenv run pytest
+      run: pipenv run pytest -m "not network"


### PR DESCRIPTION
L'API Sirene n'est pas fiable est provoque des erreurs non significatives. Les tests réseau sont désactivés pour contourner ce problème.