### PR TITLE
résout un problème de performance d'appels à la base de donnée

### DIFF
--- a/impact/public/tests/test_simulation.py
+++ b/impact/public/tests/test_simulation.py
@@ -330,7 +330,9 @@ def test_lors_d_une_simulation_les_donnees_d_une_entreprise_avec_des_caracterist
         "appartient_groupe": False,
     }
 
-    mock_calcule_reglementations = mocker.patch("public.views.calcule_reglementations")
+    mock_est_soumis = mocker.patch(
+        "reglementations.views.base.Reglementation.est_soumis"
+    )
 
     response = client.post("/simulation", data=data, follow=True)
 
@@ -371,8 +373,8 @@ def test_lors_d_une_simulation_les_donnees_d_une_entreprise_avec_des_caracterist
     assert caracteristiques.bdese_accord
     assert caracteristiques.systeme_management_energie
 
-    mock_calcule_reglementations.assert_called_once()
-    caracteristiques_simulees = mock_calcule_reglementations.call_args.args[0]
+    assert mock_est_soumis.called
+    caracteristiques_simulees = mock_est_soumis.call_args.args[0]
     assert caracteristiques_simulees.entreprise.siren == data["siren"]
     assert caracteristiques_simulees.entreprise.denomination == data["denomination"]
     assert (
@@ -435,7 +437,9 @@ def test_lors_d_une_simulation_les_donnees_d_une_entreprise_avec_utilisateur_ne_
         "tranche_bilan_consolide": bilan_consolide,
     }
 
-    mock_calcule_reglementations = mocker.patch("public.views.calcule_reglementations")
+    mock_est_soumis = mocker.patch(
+        "reglementations.views.base.Reglementation.est_soumis"
+    )
 
     response = client.post("/simulation", data=data, follow=True)
 
@@ -450,8 +454,8 @@ def test_lors_d_une_simulation_les_donnees_d_une_entreprise_avec_utilisateur_ne_
     assert entreprise.comptes_consolides is None
     assert not entreprise.caracteristiques_actuelles()
 
-    mock_calcule_reglementations.assert_called_once()
-    caracteristiques_simulees = mock_calcule_reglementations.call_args.args[0]
+    assert mock_est_soumis.called
+    caracteristiques_simulees = mock_est_soumis.call_args.args[0]
     assert caracteristiques_simulees.entreprise.siren == data["siren"]
     assert caracteristiques_simulees.entreprise.denomination == data["denomination"]
     assert (
@@ -530,7 +534,9 @@ def test_lors_d_une_simulation_les_donnees_d_une_entreprise_sans_caracteristique
         "tranche_bilan_consolide": bilan_consolide,
     }
 
-    mock_calcule_reglementations = mocker.patch("public.views.calcule_reglementations")
+    mock_est_soumis = mocker.patch(
+        "reglementations.views.base.Reglementation.est_soumis"
+    )
 
     response = client.post("/simulation", data=data, follow=True)
 
@@ -552,8 +558,8 @@ def test_lors_d_une_simulation_les_donnees_d_une_entreprise_sans_caracteristique
     assert caracteristiques.tranche_chiffre_affaires_consolide == ca_consolide
     assert caracteristiques.tranche_bilan_consolide == bilan_consolide
 
-    mock_calcule_reglementations.assert_called_once()
-    caracteristiques_simulees = mock_calcule_reglementations.call_args.args[0]
+    assert mock_est_soumis.called
+    caracteristiques_simulees = mock_est_soumis.call_args.args[0]
     assert caracteristiques_simulees.entreprise.siren == data["siren"]
     assert caracteristiques_simulees.entreprise.denomination == data["denomination"]
     assert (

--- a/impact/reglementations/tests/test_bdese_reglementation.py
+++ b/impact/reglementations/tests/test_bdese_reglementation.py
@@ -1,5 +1,4 @@
 import pytest
-from django.contrib.auth.models import AnonymousUser
 from django.urls import reverse
 
 from entreprises.models import CaracteristiquesAnnuelles
@@ -41,62 +40,6 @@ def test_n_est_pas_suffisamment_qualifiee_car_sans_effectif(entreprise_non_quali
     caracteristiques = CaracteristiquesAnnuelles(entreprise=entreprise_non_qualifiee)
 
     assert not BDESEReglementation.est_suffisamment_qualifiee(caracteristiques)
-
-
-@pytest.mark.parametrize("est_soumis", [True, False])
-def test_calculate_status_with_not_authenticated_user(
-    est_soumis, entreprise_factory, mocker
-):
-    entreprise = entreprise_factory()
-    login_url = f"{reverse('users:login')}?next={reverse('reglementations:tableau_de_bord', args=[entreprise.siren])}"
-
-    mocker.patch(
-        "reglementations.views.bdese.BDESEReglementation.est_soumis",
-        return_value=est_soumis,
-    )
-    status = BDESEReglementation.calculate_status(
-        entreprise.dernieres_caracteristiques_qualifiantes, AnonymousUser()
-    )
-
-    if est_soumis:
-        assert status.status == ReglementationStatus.STATUS_SOUMIS
-        assert (
-            status.status_detail
-            == f'Vous êtes soumis à cette réglementation. <a href="{login_url}">Connectez-vous pour en savoir plus.</a>'
-        )
-    else:
-        assert status.status == ReglementationStatus.STATUS_NON_SOUMIS
-        assert status.status_detail == "Vous n'êtes pas soumis à cette réglementation."
-    assert status.primary_action is None
-    assert status.secondary_actions == []
-
-
-@pytest.mark.parametrize("est_soumis", [True, False])
-def test_calculate_status_with_not_attached_user(
-    est_soumis, entreprise_factory, alice, mocker
-):
-    entreprise = entreprise_factory()
-
-    mocker.patch(
-        "reglementations.views.bdese.BDESEReglementation.est_soumis",
-        return_value=est_soumis,
-    )
-    status = BDESEReglementation.calculate_status(
-        entreprise.dernieres_caracteristiques_qualifiantes, alice
-    )
-
-    if est_soumis:
-        assert status.status == ReglementationStatus.STATUS_SOUMIS
-        assert (
-            status.status_detail == "L'entreprise est soumise à cette réglementation."
-        )
-    else:
-        assert status.status == ReglementationStatus.STATUS_NON_SOUMIS
-        assert (
-            status.status_detail
-            == "L'entreprise n'est pas soumise à cette réglementation."
-        )
-    assert status.secondary_actions == []
 
 
 @pytest.mark.parametrize(

--- a/impact/reglementations/tests/test_bges_reglementation.py
+++ b/impact/reglementations/tests/test_bges_reglementation.py
@@ -1,5 +1,4 @@
 import pytest
-from django.contrib.auth.models import AnonymousUser
 from django.urls import reverse
 from freezegun import freeze_time
 
@@ -65,63 +64,6 @@ def test_n_est_pas_suffisamment_qualifiee_car_sans_effectif_outre_mer(
     )
 
     assert not BGESReglementation.est_suffisamment_qualifiee(caracteristiques)
-
-
-@pytest.mark.parametrize("est_soumis", [True, False])
-def test_calculate_status_with_not_authenticated_user(
-    est_soumis, entreprise_factory, mocker
-):
-    entreprise = entreprise_factory()
-    login_url = f"{reverse('users:login')}?next={reverse('reglementations:tableau_de_bord', args=[entreprise.siren])}"
-
-    mocker.patch(
-        "reglementations.views.bges.BGESReglementation.est_soumis",
-        return_value=est_soumis,
-    )
-    status = BGESReglementation.calculate_status(
-        entreprise.dernieres_caracteristiques_qualifiantes, AnonymousUser()
-    )
-
-    if est_soumis:
-        assert status.status == ReglementationStatus.STATUS_SOUMIS
-        assert (
-            status.status_detail
-            == f'Vous êtes soumis à cette réglementation. <a href="{login_url}">Connectez-vous pour en savoir plus.</a>'
-        )
-    else:
-        assert status.status == ReglementationStatus.STATUS_NON_SOUMIS
-        assert status.status_detail == "Vous n'êtes pas soumis à cette réglementation."
-    assert status.primary_action == ACTION_CONSULTER
-    assert status.secondary_actions == []
-
-
-@pytest.mark.parametrize("est_soumis", [True, False])
-def test_calculate_status_with_not_attached_user(
-    est_soumis, entreprise_factory, alice, mocker
-):
-    entreprise = entreprise_factory()
-
-    mocker.patch(
-        "reglementations.views.bges.BGESReglementation.est_soumis",
-        return_value=est_soumis,
-    )
-    status = BGESReglementation.calculate_status(
-        entreprise.dernieres_caracteristiques_qualifiantes, alice
-    )
-
-    if est_soumis:
-        assert status.status == ReglementationStatus.STATUS_SOUMIS
-        assert (
-            status.status_detail == "L'entreprise est soumise à cette réglementation."
-        )
-    else:
-        assert status.status == ReglementationStatus.STATUS_NON_SOUMIS
-        assert (
-            status.status_detail
-            == "L'entreprise n'est pas soumise à cette réglementation."
-        )
-    assert status.primary_action is None
-    assert status.secondary_actions == []
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
La page du tableau de bord faisait de nombreux appels identiques à la base de données pour calculer le statut de chaque réglementation car ce calcul vérifiait l'habilitation de l'utilisateur à accéder à cette information.
En supprimant cette vérification au niveau du calcul du statut et donc en déplaçant cette responsabilité à la vue (qui faisait déjà cette vérification), on simplifie le code et on résout le problème de performance.
Issue sentry liée : 108474