### PR TITLE
Séparation des domaines du site et de l'admin Django

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -15,6 +15,7 @@ sentry-sdk = "~=2.8.0"
 django-vite = "~=2.1.3"
 django-anymail = {extras = ["sendinblue"], version = "~=10.1"}
 python-dateutil = "~=2.9.0"
+django-hosts = "~=6.0"
 
 [dev-packages]
 pytest-django = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "b0cc57a172a0ca57e138e08ceb903ab43c9f59005c071d5c9bd8ff7a57b2ff86"
+            "sha256": "2a99d089046f9108f5f6b77731b08dc50e2e76986f5d598baa7360326ced4326"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -307,12 +307,12 @@
         },
         "django": {
             "hashes": [
-                "sha256:61ee4a130efb8c451ef3467c67ca99fdce400fedd768634efc86a68c18d80d30",
-                "sha256:c77f926b81129493961e19c0e02188f8d07c112a1162df69bfab178ae447f94a"
+                "sha256:1ddc333a16fc139fd253035a1606bb24261951bbc3a6ca256717fa06cc41a898",
+                "sha256:6f1616c2786c408ce86ab7e10f792b8f15742f7b7b7460243929cb371e7f1dad"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==4.2.15"
+            "version": "==4.2.16"
         },
         "django-anymail": {
             "extras": [
@@ -324,6 +324,15 @@
             ],
             "markers": "python_version >= '3.7'",
             "version": "==10.3"
+        },
+        "django-hosts": {
+            "hashes": [
+                "sha256:34a97a183b3fb8a00de3e0a8af5355a25ff5203019d2e213edd8f12c330cc303",
+                "sha256:e7aec357504d36f384c65fba67deabc4552f36f347b96bb7a3d131a1250d7299"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==6.0"
         },
         "django-vite": {
             "hashes": [
@@ -822,12 +831,12 @@
         },
         "pytest-django": {
             "hashes": [
-                "sha256:5d054fe011c56f3b10f978f41a8efb2e5adfc7e680ef36fb571ada1f24779d90",
-                "sha256:ca1ddd1e0e4c227cf9e3e40a6afc6d106b3e70868fd2ac5798a22501271cd0c7"
+                "sha256:1d83692cb39188682dbb419ff0393867e9904094a549a7d38a3154d5731b2b99",
+                "sha256:8bf7bc358c9ae6f6fc51b6cebb190fe20212196e6807121f11bd6a3b03428314"
             ],
             "index": "pypi",
             "markers": "python_version >= '3.8'",
-            "version": "==4.8.0"
+            "version": "==4.9.0"
         },
         "pytest-mock": {
             "hashes": [

--- a/impact/impact/admin_urls.py
+++ b/impact/impact/admin_urls.py
@@ -1,0 +1,8 @@
+from django.contrib import admin
+from django.urls import path
+
+# URLs / path for the admin site
+
+urlpatterns = [
+    path("", admin.site.urls),
+]

--- a/impact/impact/hosts.py
+++ b/impact/impact/hosts.py
@@ -1,0 +1,14 @@
+from django.conf import settings
+from django_hosts import host
+from django_hosts import patterns
+
+# Two (virtual) hosts defined : admin and actual site.
+# Just don't forget to update ALLOWED_HOSTS in the settings.
+
+host_patterns = patterns(
+    "",
+    # first, be specific : check if we want to access to the admin site:
+    host(rf"{settings.ADMIN_CNAME}", "impact.admin_urls", name="admin"),
+    # otherwise, use a catch-all regexp to point to the actual site:
+    host(r"(\w+)", settings.ROOT_URLCONF, name="site"),
+)

--- a/impact/impact/settings.py
+++ b/impact/impact/settings.py
@@ -48,8 +48,10 @@ INSTALLED_APPS = [
     "django.contrib.postgres",
     "django_vite",
     "anymail",
+    "django_hosts",
 ]
 MIDDLEWARE = [
+    "django_hosts.middleware.HostsRequestMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
@@ -58,6 +60,7 @@ MIDDLEWARE = [
     "django.contrib.auth.middleware.AuthenticationMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
+    "django_hosts.middleware.HostsResponseMiddleware",
 ]
 ROOT_URLCONF = "impact.urls"
 TEMPLATES = [
@@ -197,3 +200,11 @@ if SENTRY_DSN:
 # API
 API_INSEE_KEY = os.getenv("API_INSEE_KEY")
 API_INSEE_TOKEN_PATH = Path("/tmp/jeton_insee")
+
+# django-hosts :
+# https://django-hosts.readthedocs.io/en/latest/
+ROOT_HOSTCONF = "impact.hosts"
+DEFAULT_HOST = "site"
+
+# CNAME of the admin site
+ADMIN_CNAME = os.getenv("ADMIN_CNAME", "admin")

--- a/impact/impact/urls.py
+++ b/impact/impact/urls.py
@@ -15,7 +15,6 @@ Including another URLconf
 """
 from django.conf import settings
 from django.conf.urls.static import static
-from django.contrib import admin
 from django.urls import include
 from django.urls import path
 
@@ -24,11 +23,12 @@ def trigger_error(request):
     division_by_zero = 1 / 0  # noqa
 
 
+# note : admin site path is in a distinct file for `django-hosts`
+
 urlpatterns = [
     path("", include("public.urls")),
     path("", include("entreprises.urls")),
     path("", include("reglementations.urls")),
     path("", include("users.urls")),
-    path("admin/", admin.site.urls),
     path("trigger-error-for-sentry-debug/", trigger_error),
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)


### PR DESCRIPTION
Relatif à : https://trello.com/c/cGmNFxHm/106-homologuer-le-service

Le site d'admin de Django est séparé du site du Portail RSE suite à recommandation de l'audit de sécurité : 
- installation de [`django-hosts`](https://github.com/jazzband/django-hosts),
- le nom du site d'admin peut être configuré via la variable d'environnement `ADMIN_CNAME` (par défaut : `admin`),
- ne pas oublier de modifier `ALLOWED_HOSTS` pour y inclure l'URL du site d'admin.

Si possible, intégrer cette PR *avant* la PR de CSP (#131) pour pouvoir effectuer les ajustements.

Pour tester en local / dev, ajouter une résolution du nom du site d'admin. 
Par exemple, sous Linux, en ajoutant une ligne dans `/etc/hosts`  : 
```bash 
127.0.0.1 admin # ou autre
``