### PR TITLE
fix: suppression d'un warning javascript

### DIFF
--- a/front/src/lib/SeeMoreOrLess.svelte
+++ b/front/src/lib/SeeMoreOrLess.svelte
@@ -11,7 +11,7 @@
       let linkText = document.createTextNode(actionLabel);
       link.appendChild(linkText);
       link.addEventListener("click", () => action());
-      link.href = "javascript: void()";
+      link.href = "javascript: void(0)";
 
       while (label.firstChild) {
         label.removeChild(label.firstChild);


### PR DESCRIPTION
L'absence de paramètre à la fonction `void()` provoque une erreur "Uncaught SyntaxError: expected expression, got ')'" non bloquante.
Cela provoque aussi l'envoi d'un rapport CSP.
