### PR TITLE
fix: suppression d'une erreur CSP en supprimant le javascript fautif

### DIFF
--- a/front/src/lib/SeeMoreOrLess.svelte
+++ b/front/src/lib/SeeMoreOrLess.svelte
@@ -6,12 +6,12 @@
     const label = document.getElementById("svelte-voir-plus-moins-label")
 
     const newLink = (prefixActionLabel, actionLabel, action) => {
-      let link = document.createElement('a');
+      let link = document.createElement('span');
       link.classList.add("fr-link");
+      link.classList.add("mimic-link");
       let linkText = document.createTextNode(actionLabel);
       link.appendChild(linkText);
       link.addEventListener("click", () => action());
-      link.href = "javascript: void(0)";
 
       while (label.firstChild) {
         label.removeChild(label.firstChild);

--- a/impact/static/scss/styles.scss
+++ b/impact/static/scss/styles.scss
@@ -102,6 +102,20 @@
     background-color: var(--background-alt-blue-france);
 }
 
+/* l'imitation graphique de lien nécessite l'utilisation de la classe fr-link */
+.mimic-link {
+    cursor: pointer;
+    text-decoration: none;
+    background-image: var(--underline-img),var(--underline-img);
+    background-position: var(--underline-x) 100%,var(--underline-x) calc(100% - var(--underline-thickness));
+    background-repeat: no-repeat,no-repeat;
+    background-size: var(--underline-hover-width) calc(var(--underline-thickness)*2),var(--underline-idle-width) var(--underline-thickness);
+    transition: background-size 0s;
+}
+.mimic-link:active, .mimic-link:hover {
+    --underline-hover-width: var(--underline-max-width);
+}
+
 /* homepage */
 
 .logo-rse {


### PR DESCRIPTION
Plutôt que d'accepter du javascript inline dans les CSP, le remplacement du javascript incriminé par une solution fonctionnellement équivalente permet d'éviter l'erreur CSP sans affaiblir la configuration CSP.