### PR TITLE
chore: reduce sentry tracesSampleRate

### DIFF
--- a/impact/impact/settings.py
+++ b/impact/impact/settings.py
@@ -195,7 +195,7 @@ if SENTRY_DSN:
         # Set traces_sample_rate to 1.0 to capture 100%
         # of transactions for performance monitoring.
         # We recommend adjusting this value in production.
-        traces_sample_rate=1.0,
+        traces_sample_rate=0.1,
         # If you wish to associate users to errors (assuming you are using
         # django.contrib.auth) you may enable sending PII data.
         send_default_pii=True,


### PR DESCRIPTION
Reduce sentry `tracesSampleRate` as it produces +100k events/day

<img width="788" alt="Capture d’écran 2024-09-17 à 13 55 02" src="https://github.com/user-attachments/assets/cc6d97fe-cb57-48ae-9318-92a2d290f271">
