### PR TITLE
installation de django-debug-toolbar

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,3 +9,4 @@ CONTACT_EMAIL=portail-rse@domain.example
 API_INSEE_KEY=
 MATOMO_DISABLED=true
 CSP_MODE=
+DEBUG_TOOLBAR=

--- a/Pipfile
+++ b/Pipfile
@@ -26,6 +26,7 @@ pytest-mock = "*"
 freezegun = "*"
 pre-commit = "*"
 honcho = "*"
+django-debug-toolbar = "*"
 exceptiongroup = {version = "~=1.2.2", markers="python_version < '3.11'"}
 
 [requires]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "1a40e1790097524fd206323b43274033915a3214ec0aae627d9138a5f336950b"
+            "sha256": "dbd2fc040cc5d2e126a39be7eff1c80204e8eaf7fcb219618ae0ffd4d89db858"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -728,6 +728,14 @@
         }
     },
     "develop": {
+        "asgiref": {
+            "hashes": [
+                "sha256:3e1e3ecc849832fe52ccf2cb6686b7a55f82bb1d6aee72a58826471390335e47",
+                "sha256:c343bd80a0bec947a9860adb4c432ffa7db769836c64238fc34bdc3fec84d590"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==3.8.1"
+        },
         "cfgv": {
             "hashes": [
                 "sha256:b7265b1f29fd3316bfcd2b330d63d024f2bfd8bcb8b0272f8e19a504856c48f9",
@@ -742,6 +750,23 @@
                 "sha256:1530ea13e350031b6312d8580ddb6b27a104275a31106523b8f123787f494f64"
             ],
             "version": "==0.3.8"
+        },
+        "django": {
+            "hashes": [
+                "sha256:1ddc333a16fc139fd253035a1606bb24261951bbc3a6ca256717fa06cc41a898",
+                "sha256:6f1616c2786c408ce86ab7e10f792b8f15742f7b7b7460243929cb371e7f1dad"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==4.2.16"
+        },
+        "django-debug-toolbar": {
+            "hashes": [
+                "sha256:36e421cb908c2f0675e07f9f41e3d1d8618dc386392ec82d23bcfcd5d29c7044",
+                "sha256:3beb671c9ec44ffb817fad2780667f172bd1c067dbcabad6268ce39a81335f45"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.8'",
+            "version": "==4.4.6"
         },
         "exceptiongroup": {
             "hashes": [
@@ -934,6 +959,14 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.16.0"
+        },
+        "sqlparse": {
+            "hashes": [
+                "sha256:773dcbf9a5ab44a090f3441e2180efe2560220203dc2f8c0b0fa141e18b505e4",
+                "sha256:bb6b4df465655ef332548e24f08e205afc81b9ab86cb1c45657a7ff173a3a00e"
+            ],
+            "markers": "python_version >= '3.8'",
+            "version": "==0.5.1"
         },
         "virtualenv": {
             "hashes": [

--- a/impact/impact/settings.py
+++ b/impact/impact/settings.py
@@ -318,3 +318,16 @@ if CSP_MODE != "disabled":
     # register django-csp app
     INSTALLED_APPS.append("csp")
     MIDDLEWARE.append("csp.middleware.CSPMiddleware")
+
+if DEBUG_TOOLBAR := os.getenv("DEBUG_TOOLBAR"):
+    INSTALLED_APPS.append("debug_toolbar")
+    INTERNAL_IPS = ["127.0.0.1"]
+
+    # DebugToolbarMiddleware doit être après HostsRequestMiddleware
+    MIDDLEWARE.insert(
+        MIDDLEWARE.index(
+            "django_hosts.middleware.HostsRequestMiddleware",
+        )
+        + 1,
+        "debug_toolbar.middleware.DebugToolbarMiddleware",
+    )

--- a/impact/impact/urls.py
+++ b/impact/impact/urls.py
@@ -18,6 +18,9 @@ from django.conf.urls.static import static
 from django.urls import include
 from django.urls import path
 
+if settings.DEBUG_TOOLBAR:
+    from debug_toolbar.toolbar import debug_toolbar_urls
+
 
 def trigger_error(request):
     division_by_zero = 1 / 0  # noqa
@@ -32,3 +35,6 @@ urlpatterns = [
     path("", include("users.urls")),
     path("trigger-error-for-sentry-debug/", trigger_error),
 ] + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
+
+if settings.DEBUG_TOOLBAR:
+    urlpatterns.extend(debug_toolbar_urls())


### PR DESCRIPTION
Permet à tous les développeurs du projet d'avoir la barre de [django-debug-toolbar](https://django-debug-toolbar.readthedocs.io/en/latest/index.html) dans l'interface web.

Pour cela, il suffit d'ajouter la ligne `DEBUG_TOOLBAR=True` dans le fichier `.env`.
