### PR TITLE
refacto: déplacement de fonctions dédiées à egapro

### DIFF
--- a/impact/reglementations/models/__init__.py
+++ b/impact/reglementations/models/__init__.py
@@ -1,5 +1,6 @@
 from .bdse import *  # noqa
 from .csrd import *  # noqa
+from .index_egapro import *  # noqa
 
 # This uncommon structure of modules (included in a heigh-level package)
 # can be useful for domains / apps with a big number of models and/or complex ones.

--- a/impact/reglementations/models/bdse.py
+++ b/impact/reglementations/models/bdse.py
@@ -11,20 +11,6 @@ from entreprises.models import Entreprise
 from utils.models import TimestampedModel
 
 
-def derniere_annee_a_publier_index_egapro():
-    annee = datetime.date.today().year
-    return annee - 1
-
-
-def prochaine_echeance_index_egapro(derniere_annee_est_publiee: bool) -> datetime.date:
-    aujourdhui = datetime.date.today()
-    annee = aujourdhui.year
-    if derniere_annee_est_publiee:
-        return datetime.date(annee + 1, 3, 1)
-    else:
-        return datetime.date(annee, 3, 1)
-
-
 def derniere_annee_a_remplir_bdese():
     annee = datetime.date.today().year
     return annee - 1

--- a/impact/reglementations/models/index_egapro.py
+++ b/impact/reglementations/models/index_egapro.py
@@ -1,0 +1,15 @@
+import datetime
+
+
+def derniere_annee_a_publier_index_egapro():
+    annee = datetime.date.today().year
+    return annee - 1
+
+
+def prochaine_echeance_index_egapro(derniere_annee_est_publiee: bool) -> datetime.date:
+    aujourdhui = datetime.date.today()
+    annee = aujourdhui.year
+    if derniere_annee_est_publiee:
+        return datetime.date(annee + 1, 3, 1)
+    else:
+        return datetime.date(annee, 3, 1)


### PR DESCRIPTION
Les deux fonctions sont déplacées dans leur propre fichier. Cela reste transparent pour le reste du code.