### PR TITLE
Adaptation des scripts Matomo pour la CSP

### DIFF
--- a/impact/templates/base.html
+++ b/impact/templates/base.html
@@ -23,20 +23,21 @@
         <script type="text/javascript" src="{% static 'js/htmx.min.js' %}" nonce="{{ request.csp_nonce }}" defer></script>
 
         {% if matomo_enabled %}
-        <!-- Matomo -->
-            <script nonce="{{ request.csp_nonce }}">
+		<!-- Matomo -->
+            <script type="text/javascript" nonce="{{ request.csp_nonce }}">
                 var _paq = window._paq = window._paq || [];
-                /* tracker methods like "setCustomDimension" should be called before "trackPageView" */
-                _paq.push(["setExcludedQueryParams", ["simulationId","_csrf"]]);
                 _paq.push(['trackPageView']);
                 _paq.push(['enableLinkTracking']);
+                _paq.push(["setExcludedQueryParams", ["simulationId", "_csrf"]]);
                 (function() {
                     var u="https://stats.beta.gouv.fr/";
                     _paq.push(['setTrackerUrl', u+'matomo.php']);
                     _paq.push(['setSiteId', '16']);
+                    var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
+                    g.type='text/javascript'; g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
                 })();
             </script>
-        <!-- End Matomo Code -->
+		<!-- End Matomo Code -->
         {% endif %}
     </head>
     <body>


### PR DESCRIPTION
Les scripts Matomo n'ont remonté aucune erreur durant la phase de test des CSP en mode `report-only`.

Contrairement aux autres éléments et scripts qui généraient des erreurs (Sentry et console), Matomo échouait à "bas-bruit".

Le problème peut apparemment être résolu en suivant ces instructions: https://matomo.org/faq/general/faq_20904/ .. ce qui est exactement ce que nous avons fait (`nonce`).

Par contre en modifiant légèrement le script inclus dans Matomo (voir https://developer.matomo.org/guides/tracking-javascript-guide), tout semble fonctionner correctement sur l'environnement de recette.

On retrouve désormais les appels de `trackview` vers Matomo en mode CSP (absents auparavant) : 
![image](https://github.com/user-attachments/assets/3b22ce1e-66f6-4fcd-9c2d-132d104d5e8b)

 