### PR TITLE
fix: suppression du texte "Panneau de gestion des cookies" en bas de …

### DIFF
--- a/impact/static/scss/dsfr-theme-tac.scss
+++ b/impact/static/scss/dsfr-theme-tac.scss
@@ -1114,5 +1114,9 @@ ul[style="display: block;"] .tarteaucitronLine{
   outline: 2px solid;
   outline-color: var(--focus);
   outline-offset: 2px;
-  z-index: var(--focus-z-index); 
+  z-index: var(--focus-z-index);
+}
+
+.tac_visually-hidden {
+  display: none;
 }


### PR DESCRIPTION
…page

Ce titre du tarte au citron apparaît en bas de page (sous le pied-de-page) alors qu'il ne devrait pas.