### PR TITLE
limitation de la longueur des fonctions exercées dans une entreprise

### DIFF
--- a/impact/habilitations/models.py
+++ b/impact/habilitations/models.py
@@ -10,6 +10,7 @@ from reglementations.models import get_all_personal_bdese
 from reglementations.models import has_official_bdese
 from utils.models import TimestampedModel
 
+FONCTIONS_MIN_LENGTH = 3
 FONCTIONS_MAX_LENGTH = 250
 
 

--- a/impact/users/forms.py
+++ b/impact/users/forms.py
@@ -7,6 +7,8 @@ from django.core.exceptions import ValidationError
 
 from .models import User
 from entreprises.forms import SirenField
+from habilitations.models import FONCTIONS_MAX_LENGTH
+from habilitations.models import FONCTIONS_MIN_LENGTH
 from utils.forms import DsfrForm
 
 
@@ -73,7 +75,11 @@ class UserPasswordForm(DsfrForm, forms.ModelForm):
 
 class UserCreationForm(UserPasswordForm):
     siren = SirenField()
-    fonctions = forms.CharField(label="Fonction(s) dans la société")
+    fonctions = forms.CharField(
+        label="Fonction(s) dans la société",
+        min_length=FONCTIONS_MIN_LENGTH,
+        max_length=FONCTIONS_MAX_LENGTH,
+    )
     acceptation_cgu = forms.BooleanField(
         label="J’ai lu et j’accepte les CGU (Conditions Générales d'utilisation)",
         required=True,


### PR DESCRIPTION
Des utilisateurs signalent l'incapacité de créer un compte sans que ce soit bien compris de notre côté.
En contrôlant mieux la longueur acceptée pour les fonctions exercées dans l'entreprise, cela permettra peut-être d'aiguiller les utilisateurs, et sinon d'éliminer l'hypothèse que ce soit cela le problème.