### PR TITLE
Separation sites faciles

### DIFF
--- a/impact/public/templates/public/index.html
+++ b/impact/public/templates/public/index.html
@@ -8,7 +8,7 @@
                 <div class="fr-notice__body">
                     <p class="fr-notice__title">
                         Accédez à l'Espace de Rapport de Durabilité (CSRD) :
-                        <a href="{% url 'reglementations:csrd' %}" title="Espace Rapport de Durabilité">Découvrir</a>
+                        <a href="https://portail-rse.beta.gouv.fr/realiser-le-rapport-de-durabilite/" title="Espace Rapport de Durabilité">Découvrir</a>
                     </p>
                 </div>
             </div>
@@ -69,7 +69,7 @@
                             <div class="fr-card__footer">
                                 <ul class="fr-btns-group">
                                     <li>
-                                        <a href="{% url 'reglementations' %}" class="fr-btn fr-btn--secondary">
+                                        <a href="https://portail-rse.beta.gouv.fr/fiches-reglementaires" class="fr-btn fr-btn--secondary">
                                             Consulter les fiches réglementaires
                                         </a>
                                     </li>

--- a/impact/templates/base.html
+++ b/impact/templates/base.html
@@ -123,25 +123,7 @@
                                             <li class="fr-nav__item"><a class="fr-nav__link" href="{{ url_page }}" target="_self"{% if request.path == url_page %} aria-current="page"{% endif %}>Tableau de bord</a></li>
                                         {% endfor %}
                                     {% endif %}
-                                    {% if user.entreprise_set.count >= 2 %}
-                                        <li class="fr-nav__item">
-                                            {% url 'reglementations:csrd' entreprise.siren as csrd_path %}
-                                            <button class="fr-nav__btn" aria-expanded="false" aria-controls="menu-2" {% if request.path == csrd_path %} aria-current="page"{% endif %}>
-                                                Espace Rapport de Durabilité
-                                            </button>
-                                            <div class="fr-collapse fr-menu" id="menu-2">
-                                                <ul class="fr-menu__list">
-                                                    {% for entreprise in user.entreprises %}
-                                                        {% url 'reglementations:csrd' entreprise.siren as csrd_path %}
-                                                        <li><a class="fr-nav__link" href="{{ csrd_path }}" target="_self"{% if request.path == csrd_path %} aria-current="page"{% endif %}>{{ entreprise.denomination }}</a></li>
-                                                    {% endfor %}
-                                                </ul>
-                                            </div>
-                                        </li>
-                                    {% elif user.entreprise_set.count == 1 %}
-                                        {% url 'reglementations:csrd' user.entreprise_set.first.siren as csrd_path %}
-                                        <li class="fr-nav__item"><a class="fr-nav__link" href="{{ csrd_path }}" target="_self"{% if request.path == csrd_path %} aria-current="page"{% endif %}>Espace Rapport de Durabilité</a></li>
-                                    {% endif %}
+                                    <li class="fr-nav__item"><a class="fr-nav__link" href="https://portail-rse.beta.gouv.fr/realiser-le-rapport-de-durabilite/" target="_self"{% if request.path == csrd_path %} aria-current="page"{% endif %}>Espace Rapport de Durabilité</a></li>
                                 </ul>
                             </nav>
                         {% endif %}

--- a/impact/templates/base.html
+++ b/impact/templates/base.html
@@ -58,7 +58,7 @@
                                         <li><a class="fr-btn fr-tool-link fr-icon-mail-fill" href="{% url 'contact' %}">Contactez-nous</a></li>
                                         {% url 'simulation' as url_simulation %}
                                         {% if url_simulation not in request.path and not user.is_authenticated %}
-                                            <li><a class="fr-btn fr-tool-link fr-icon-file-text-fill" href="{% url 'reglementations' %}">Fiches réglementaires RSE</a></li>
+                                            <li><a class="fr-btn fr-tool-link fr-icon-file-text-fill" href="https://portail-rse.beta.gouv.fr/fiches-reglementaires">Fiches réglementaires RSE</a></li>
                                         {% endif %}
 
                                         {% if user.is_authenticated %}


### PR DESCRIPTION
Avec la séparation du site en deux : le versant vitrine fait avec sites-faciles et le code métier qui reste dans le dépôt portail-rse, il est nécessaire de pointer certaines pages vers le site vitrine.