### PR TITLE
Paramétrage du domaine sur lequel les cookies s'appliquent

### DIFF
--- a/impact/impact/settings.py
+++ b/impact/impact/settings.py
@@ -142,6 +142,8 @@ SESSION_COOKIE_SECURE = True
 # Session expires when browser is closed
 SESSION_EXPIRE_AT_BROWSER_CLOSE = True
 
+COOKIE_DOMAIN = os.getenv("COOKIE_DOMAIN", "")
+
 # SameSite :
 # must be "Strict", other sites do not need to see session cookies
 # TO BE CONFIRMED ...

--- a/impact/templates/base.html
+++ b/impact/templates/base.html
@@ -235,6 +235,7 @@
                     "moreInfoLink": false,
                     "mandatory": true,
                     "mandatoryCta": false,
+                    "cookieDomain": "{{ cookie_domain }}",
                 });
 	    // Service Youtube
                 (tarteaucitron.job = tarteaucitron.job || []).push('youtube');

--- a/impact/utils/context_processors.py
+++ b/impact/utils/context_processors.py
@@ -4,6 +4,7 @@ from django.conf import settings
 def custom_settings(_):
     # allows direct access to some relevant settings
     return {
+        "cookie_domain": settings.COOKIE_DOMAIN,
         "matomo_enabled": not settings.MATOMO_DISABLED,
         "sentry_dsn": settings.SENTRY_DSN,
         "sentry_env": settings.SENTRY_ENV,


### PR DESCRIPTION
Une variable d'environnement facultative permet de choisir sur quel domaine les cookies de tarteaucitron s'appliquent. Cela permet en production de les mettre sur l'ensemble du domaine portail-rse et donc qu'ils soient valides sur le service sites-facile ainsi que le service de ce dépôt (app.portail...).