### PR TITLE
Disponibilité des liens du menu sur une URL

### DIFF
--- a/impact/public/templatetags/absolute_url.py
+++ b/impact/public/templatetags/absolute_url.py
@@ -1,0 +1,10 @@
+from django import template
+from django.shortcuts import reverse
+
+register = template.Library()
+
+
+@register.simple_tag(takes_context=True)
+def absolute_url(context, view_name, *args, **kwargs):
+    request = context["request"]
+    return request.build_absolute_uri(reverse(view_name, args=args, kwargs=kwargs))

--- a/impact/public/tests/tests.py
+++ b/impact/public/tests/tests.py
@@ -2,6 +2,7 @@ import html
 
 import pytest
 from django.urls import reverse
+from pytest_django.asserts import assertTemplateUsed
 
 from habilitations.models import attach_user_to_entreprise
 from reglementations.views import REGLEMENTATIONS
@@ -192,3 +193,23 @@ def test_page_publique_des_reglementations(client):
     assert context["reglementations"] == REGLEMENTATIONS
     for REGLEMENTATION in REGLEMENTATIONS:
         assert REGLEMENTATION.title in content
+
+
+def test_fragments_liens_menu_si_visiteur_non_connecté(client):
+    response = client.get("/liens-menu")
+
+    assert response.status_code == 200
+    assertTemplateUsed(response, "snippets/boutons_menu.html")
+    content = response.content.decode("utf-8")
+    assert "Se connecter" in content
+
+
+def test_fragments_liens_menu_si_visiteur_non_connecté(client, alice):
+    client.force_login(alice)
+
+    response = client.get("/liens-menu")
+
+    assert response.status_code == 200
+    assertTemplateUsed(response, "snippets/boutons_menu.html")
+    content = response.content.decode("utf-8")
+    assert "Alice" in content

--- a/impact/public/urls.py
+++ b/impact/public/urls.py
@@ -18,4 +18,5 @@ urlpatterns = [
     path("contact", views.contact, name="contact"),
     path("reglementations", views.reglementations, name="reglementations"),
     path("stats", views.stats, name="stats"),
+    path("liens-menu", views.fragment_liens_menu, name="fragment_liens_menu"),
 ]

--- a/impact/public/views.py
+++ b/impact/public/views.py
@@ -28,6 +28,10 @@ def index(request):
     return render(request, "public/index.html")
 
 
+def fragment_liens_menu(request):
+    return render(request, "snippets/boutons_menu.html")
+
+
 def mentions_legales(request):
     return render(request, "public/mentions-legales.html")
 

--- a/impact/templates/base.html
+++ b/impact/templates/base.html
@@ -54,37 +54,7 @@
                             </div>
                             <div class="fr-header__tools">
                                 <div class="fr-header__tools-links with-btns">
-                                    <ul class="fr-btns-group">
-                                        <li><a class="fr-btn fr-tool-link fr-icon-mail-fill" href="{% url 'contact' %}">Contactez-nous</a></li>
-                                        {% url 'simulation' as url_simulation %}
-                                        {% if url_simulation not in request.path and not user.is_authenticated %}
-                                            <li><a class="fr-btn fr-tool-link fr-icon-file-text-fill" href="https://portail-rse.beta.gouv.fr/fiches-reglementaires">Fiches réglementaires RSE</a></li>
-                                        {% endif %}
-
-                                        {% if user.is_authenticated %}
-                                            <li><a class="fr-btn fr-tool-link fr-icon-building-fill" href="{% url 'entreprises:entreprises' %}">{% if user.entreprise_set.count >= 2 %}Mes entreprises{% else %}Mon entreprise{% endif %}</a></li>
-                                            <li class="fr-nav__item header-collapse">
-                                                <button class="fr-btn fr-tool-link fr-icon-account-circle-fill" aria-expanded="false" aria-controls="menu-header">{{ user.prenom|title }} {{ user.nom|title|first }}.</button>
-                                                <div class="fr-collapse fr-menu" id="menu-header">
-                                                    <ul class="fr-menu__list">
-                                                        <li><a class="fr-nav__link" href="{% url 'users:account' %}" target="_self"><span class="fr-icon-account-circle-fill fr-mr-1w" aria-hidden="true"></span> Mon compte</a></li>
-                                                        <li>
-                                                            <form>
-                                                                {% csrf_token %}
-                                                                <a class="fr-nav__link" href="#" hx-post="{% url 'users:logout' %}" hx-target="body">
-                                                                    <span class="fr-icon-lock-unlock-fill fr-mr-1w" aria-hidden="true"></span> Se déconnecter</a>
-                                                            </form>
-                                                        </li>
-                                                    </ul>
-                                                </div>
-                                            </li>
-                                        {% else %}
-                                            <li><a class="fr-btn fr-btn--secondary fr-icon-lock-fill" href="{% url 'users:login' %}?next={{ request.path }}&mtm_campaign=connexion-menu&mtm_kwd=menu">Se connecter</a></li>
-                                            {% if url_simulation not in request.path %}
-                                                <li><a class="fr-btn fr-btn--primary fr-btn--tool-links" href="{% url 'simulation' %}?mtm_campaign=simulation-menu&mtm_kwd=menu">Vérifier mes obligations</a></li>
-                                            {% endif %}
-                                        {% endif %}
-                                    </ul>
+                                    {% include "snippets/boutons_menu.html" %}
                                 </div>
                             </div>
                         </div>

--- a/impact/templates/snippets/boutons_menu.html
+++ b/impact/templates/snippets/boutons_menu.html
@@ -13,7 +13,13 @@
             <div class="fr-collapse fr-menu" id="menu-header">
                 <ul class="fr-menu__list">
                     <li><a class="fr-nav__link" href="{% absolute_url 'users:account' %}" target="_self"><span class="fr-icon-account-circle-fill fr-mr-1w" aria-hidden="true"></span> Mon compte</a></li>
-                    <li><a class="fr-nav__link" href="{% absolute_url 'users:logout' %}" target="_self"><span class="fr-icon-lock-unlock-fill fr-mr-1w" aria-hidden="true"></span> Se déconnecter</a></li>
+                    <li>
+                        <form>
+                            {% csrf_token %}
+                            <a class="fr-nav__link" href="#" hx-post="{% absolute_url 'users:logout' %}" hx-target="body">
+                                <span class="fr-icon-lock-unlock-fill fr-mr-1w" aria-hidden="true"></span> Se déconnecter</a>
+                        </form>
+                    </li>
                 </ul>
             </div>
         </li>

--- a/impact/templates/snippets/boutons_menu.html
+++ b/impact/templates/snippets/boutons_menu.html
@@ -1,24 +1,26 @@
+{% load absolute_url %}
+
 <ul class="fr-btns-group">
-    <li><a class="fr-btn fr-tool-link fr-icon-mail-fill" href="{% url 'contact' %}">Contactez-nous</a></li>
+    <li><a class="fr-btn fr-tool-link fr-icon-mail-fill" href="{% absolute_url 'contact' %}">Contactez-nous</a></li>
     {% url 'simulation' as url_simulation %}
     {% if url_simulation not in request.path and not user.is_authenticated %}
         <li><a class="fr-btn fr-tool-link fr-icon-file-text-fill" href="https://portail-rse.beta.gouv.fr/fiches-reglementaires">Fiches réglementaires RSE</a></li>
     {% endif %}
     {% if user.is_authenticated %}
-        <li><a class="fr-btn fr-tool-link fr-icon-building-fill" href="{% url 'entreprises:entreprises' %}">{% if user.entreprise_set.count >= 2 %}Mes entreprises{% else %}Mon entreprise{% endif %}</a></li>
+        <li><a class="fr-btn fr-tool-link fr-icon-building-fill" href="{% absolute_url 'entreprises:entreprises' %}">{% if user.entreprise_set.count >= 2 %}Mes entreprises{% else %}Mon entreprise{% endif %}</a></li>
         <li class="fr-nav__item header-collapse">
             <button class="fr-btn fr-tool-link fr-icon-account-circle-fill" aria-expanded="false" aria-controls="menu-header">{{ user.prenom|title }} {{ user.nom|title|first }}.</button>
             <div class="fr-collapse fr-menu" id="menu-header">
                 <ul class="fr-menu__list">
-                    <li><a class="fr-nav__link" href="{% url 'users:account' %}" target="_self"><span class="fr-icon-account-circle-fill fr-mr-1w" aria-hidden="true"></span> Mon compte</a></li>
-                    <li><a class="fr-nav__link" href="{% url 'users:logout' %}" target="_self"><span class="fr-icon-lock-unlock-fill fr-mr-1w" aria-hidden="true"></span> Se déconnecter</a></li>
+                    <li><a class="fr-nav__link" href="{% absolute_url 'users:account' %}" target="_self"><span class="fr-icon-account-circle-fill fr-mr-1w" aria-hidden="true"></span> Mon compte</a></li>
+                    <li><a class="fr-nav__link" href="{% absolute_url 'users:logout' %}" target="_self"><span class="fr-icon-lock-unlock-fill fr-mr-1w" aria-hidden="true"></span> Se déconnecter</a></li>
                 </ul>
             </div>
         </li>
     {% else %}
-        <li><a class="fr-btn fr-btn--secondary fr-icon-lock-fill" href="{% url 'users:login' %}?next={{ request.path }}&mtm_campaign=connexion-menu&mtm_kwd=menu">Se connecter</a></li>
+        <li><a class="fr-btn fr-btn--secondary fr-icon-lock-fill" href="{% absolute_url 'users:login' %}?next={{ request.path }}&mtm_campaign=connexion-menu&mtm_kwd=menu">Se connecter</a></li>
         {% if url_simulation not in request.path %}
-            <li><a class="fr-btn fr-btn--primary fr-btn--tool-links" href="{% url 'simulation' %}?mtm_campaign=simulation-menu&mtm_kwd=menu">Vérifier mes obligations</a></li>
+            <li><a class="fr-btn fr-btn--primary fr-btn--tool-links" href="{% absolute_url 'simulation' %}?mtm_campaign=simulation-menu&mtm_kwd=menu">Vérifier mes obligations</a></li>
         {% endif %}
     {% endif %}
 </ul>

--- a/impact/templates/snippets/boutons_menu.html
+++ b/impact/templates/snippets/boutons_menu.html
@@ -1,0 +1,24 @@
+<ul class="fr-btns-group">
+    <li><a class="fr-btn fr-tool-link fr-icon-mail-fill" href="{% url 'contact' %}">Contactez-nous</a></li>
+    {% url 'simulation' as url_simulation %}
+    {% if url_simulation not in request.path and not user.is_authenticated %}
+        <li><a class="fr-btn fr-tool-link fr-icon-file-text-fill" href="https://portail-rse.beta.gouv.fr/fiches-reglementaires">Fiches réglementaires RSE</a></li>
+    {% endif %}
+    {% if user.is_authenticated %}
+        <li><a class="fr-btn fr-tool-link fr-icon-building-fill" href="{% url 'entreprises:entreprises' %}">{% if user.entreprise_set.count >= 2 %}Mes entreprises{% else %}Mon entreprise{% endif %}</a></li>
+        <li class="fr-nav__item header-collapse">
+            <button class="fr-btn fr-tool-link fr-icon-account-circle-fill" aria-expanded="false" aria-controls="menu-header">{{ user.prenom|title }} {{ user.nom|title|first }}.</button>
+            <div class="fr-collapse fr-menu" id="menu-header">
+                <ul class="fr-menu__list">
+                    <li><a class="fr-nav__link" href="{% url 'users:account' %}" target="_self"><span class="fr-icon-account-circle-fill fr-mr-1w" aria-hidden="true"></span> Mon compte</a></li>
+                    <li><a class="fr-nav__link" href="{% url 'users:logout' %}" target="_self"><span class="fr-icon-lock-unlock-fill fr-mr-1w" aria-hidden="true"></span> Se déconnecter</a></li>
+                </ul>
+            </div>
+        </li>
+    {% else %}
+        <li><a class="fr-btn fr-btn--secondary fr-icon-lock-fill" href="{% url 'users:login' %}?next={{ request.path }}&mtm_campaign=connexion-menu&mtm_kwd=menu">Se connecter</a></li>
+        {% if url_simulation not in request.path %}
+            <li><a class="fr-btn fr-btn--primary fr-btn--tool-links" href="{% url 'simulation' %}?mtm_campaign=simulation-menu&mtm_kwd=menu">Vérifier mes obligations</a></li>
+        {% endif %}
+    {% endif %}
+</ul>


### PR DESCRIPTION
Le besoin est d'avoir les liens du menu sur le site vitrine identique à celui de l'app django.

Pour cela, les liens sont servis sur une nouvelle route, que le site vitrine devra requêter pour obtenir le HTML à insérer dans la page.