### PR TITLE
fix: correction de la déconnexion pour mobile

### DIFF
--- a/impact/templates/base.html
+++ b/impact/templates/base.html
@@ -101,7 +101,13 @@
                             <nav class="fr-nav" id="navigation-494" role="navigation" aria-label="Menu principal">
                                 <ul id="account-mobile" class="fr-menu__list">
                                     <li><a class="fr-nav__link" href="{% url 'users:account' %}" target="_self"><span class="fr-icon-account-circle-fill fr-mr-1w" aria-hidden="true"></span> Mon compte</a></li>
-                                    <li><a class="fr-nav__link" href="{% url 'users:logout' %}" target="_self"><span class="fr-icon-lock-unlock-fill fr-mr-1w" aria-hidden="true"></span> Se déconnecter</a></li>
+                                    <li>
+                                        <form>
+                                            {% csrf_token %}
+                                            <a class="fr-nav__link" href="#" hx-post="{% url 'users:logout' %}" hx-target="body">
+                                                <span class="fr-icon-lock-unlock-fill fr-mr-1w" aria-hidden="true"></span> Se déconnecter</a>
+                                        </form>
+                                    </li>
                                 </ul>
                                 <ul class="fr-nav__list">
                                     <li class="fr-nav__item">


### PR DESCRIPTION
Prise en compte de la correction pour Django 5, pour des petits écrans où le bouton de déconnexion est dans un autre menu.

Cela complète [la correction principale](https://github.com/betagouv/portail-rse/pull/224) pour les utilisateurs sur mobile.