### PR TITLE
fix: correction du rendu sur écran large

### DIFF
--- a/impact/public/templates/public/index.html
+++ b/impact/public/templates/public/index.html
@@ -230,8 +230,6 @@
                     </div>
                 </div>
             </div>
-        </div>
-        <div class="fr-container">
             <div class="fr-grid-row fr-grid-row--center">
                 <a href="{% url 'simulation' %}?mtm_campaign=simulation-bloc-rse&mtm_kwd=corps-page" class="fr-btn fr-btn--primary">
                     Vérifier mes obligations en 30 secondes


### PR DESCRIPTION
Le bloc principal n'était plus centré, avec le bouton d'action seul sur une seconde colonne.

On a eu deux retours utilisateurs à ce propos