### PR TITLE
ajout de l'en-tête access-control-allow-credentials

### DIFF
--- a/impact/impact/settings.py
+++ b/impact/impact/settings.py
@@ -355,3 +355,4 @@ SITES_FACILES_BASE_URL = os.getenv(
 # Élargissement autorisation CORS pour sites-faciles
 # sert pour le menu qui est téléchargé depuis le site de gestion
 CORS_ALLOWED_ORIGINS = [SITES_FACILES_BASE_URL]
+CORS_ALLOW_CREDENTIALS = True


### PR DESCRIPTION
nécessaire pour que les cookies de sesssion soient acceptés par le serveur lorsque le site vitrine fait la requête de récupération du menu