### PR TITLE
fix: redirection lors d'une connection depuis ls site vitrine

### DIFF
--- a/impact/public/views.py
+++ b/impact/public/views.py
@@ -5,6 +5,7 @@ from django.contrib import messages
 from django.core.mail import EmailMessage
 from django.shortcuts import redirect
 from django.shortcuts import render
+from django.urls import reverse
 
 from entreprises.models import ActualisationCaracteristiquesAnnuelles
 from entreprises.models import CaracteristiquesAnnuelles
@@ -29,7 +30,11 @@ def index(request):
 
 
 def fragment_liens_menu(request):
-    return render(request, "snippets/boutons_menu.html")
+    return render(
+        request,
+        "snippets/boutons_menu.html",
+        {"redirect_path": reverse("reglementations")},
+    )
 
 
 def mentions_legales(request):

--- a/impact/templates/snippets/boutons_menu.html
+++ b/impact/templates/snippets/boutons_menu.html
@@ -24,7 +24,7 @@
             </div>
         </li>
     {% else %}
-        <li><a class="fr-btn fr-btn--secondary fr-icon-lock-fill" href="{% absolute_url 'users:login' %}?next={{ request.path }}&mtm_campaign=connexion-menu&mtm_kwd=menu">Se connecter</a></li>
+        <li><a class="fr-btn fr-btn--secondary fr-icon-lock-fill" href="{% absolute_url 'users:login' %}?next={% firstof redirect_path request.path %}&mtm_campaign=connexion-menu&mtm_kwd=menu">Se connecter</a></li>
         {% if url_simulation not in request.path %}
             <li><a class="fr-btn fr-btn--primary fr-btn--tool-links" href="{% absolute_url 'simulation' %}?mtm_campaign=simulation-menu&mtm_kwd=menu">Vérifier mes obligations</a></li>
         {% endif %}


### PR DESCRIPTION
Le site vitrine récupère le lien de connection depuis une URL spécifique vers laquelle l'utiilisateur est redirigé après s'être connecté. Il faut plutôt rediriger l'utilisateur vers une page existante.