### PR TITLE
Changement du mode de déconnexion (vers GET)

### DIFF
--- a/impact/templates/snippets/boutons_menu.html
+++ b/impact/templates/snippets/boutons_menu.html
@@ -14,11 +14,7 @@
                 <ul class="fr-menu__list">
                     <li><a class="fr-nav__link" href="{% absolute_url 'users:account' %}" target="_self"><span class="fr-icon-account-circle-fill fr-mr-1w" aria-hidden="true"></span> Mon compte</a></li>
                     <li>
-                        <form>
-                            {% csrf_token %}
-                            <a class="fr-nav__link" href="#" hx-post="{% absolute_url 'users:logout' %}" hx-target="body">
-                                <span class="fr-icon-lock-unlock-fill fr-mr-1w" aria-hidden="true"></span> Se déconnecter</a>
-                        </form>
+                        <a class="fr-nav__link" href="{% absolute_url 'users:logout' %}"><span class="fr-icon-lock-unlock-fill fr-mr-1w" aria-hidden="true"></span> Se déconnecter</a>
                     </li>
                 </ul>
             </div>

--- a/impact/users/tests/test_views.py
+++ b/impact/users/tests/test_views.py
@@ -247,6 +247,22 @@ def test_echec_de_creation_car_fonctions_trop_longue(client, db):
     assert not Entreprise.objects.filter(siren="123456789")
 
 
+def test_la_déconnexion_renvoie_vers_le_site_vitrine(client, alice):
+    client.force_login(alice)
+
+    response = client.get("/deconnexion")
+
+    assert response.status_code == 302
+    assert response.url == settings.SITES_FACILES_BASE_URL
+
+
+def test_la_déconnexion_renvoie_vers_le_site_vitrine_même_si_non_connecté(client):
+    response = client.get("/deconnexion")
+
+    assert response.status_code == 302
+    assert response.url == settings.SITES_FACILES_BASE_URL
+
+
 def test_account_page_is_not_public(client):
     response = client.get("/mon-compte")
 

--- a/impact/users/urls.py
+++ b/impact/users/urls.py
@@ -7,6 +7,7 @@ from .forms import PasswordResetForm
 from .forms import SetPasswordForm
 from .views import account
 from .views import creation
+from .views import deconnexion
 from .views import PasswordResetConfirmView
 from .views import PasswordResetView
 from users.views import confirm_email
@@ -20,7 +21,7 @@ urlpatterns = [
         ),
         name="login",
     ),
-    path("deconnexion", auth_views.LogoutView.as_view(), name="logout"),
+    path("deconnexion", deconnexion, name="logout"),
     path("creation", creation, name="creation"),
     path(
         "mot-de-passe-oublie",

--- a/impact/users/views.py
+++ b/impact/users/views.py
@@ -101,6 +101,18 @@ def confirm_email(request, uidb64, token):
     return redirect("/")
 
 
+def deconnexion(request):
+    """Déconnexion par méthode GET
+
+    La déconnexion django5 utilise uniquement la méthode POST.
+    Cependant, sa réutilisation sur le site vitrine pose des problèmes d'autorisation
+    (CORS et CSRF).
+    https://docs.djangoproject.com/en/5.1/topics/auth/default/#django.contrib.auth.logout
+    """
+    logout(request)
+    return redirect(settings.SITES_FACILES_BASE_URL)
+
+
 @login_required()
 def account(request):
     account_form = UserEditionForm(instance=request.user)


### PR DESCRIPTION
Le passage de django 4 à django 5 a obligé à passer d'une déconnexion GET à POST. Cependant, la réutilisation du bloc menu sur le site vitrine provoque des erreurs dû à un manque d'autorisation CORS et CSRF.
Malgré des tentatives répétées pour ajouter la configuration adéquate pour autoriser cette requête par HTMX ou un POST basique, la requête est refusée. En repassant sur un simple lien, donc réalisé en GET, ce type de problème disparait. Cela permet de se déconnecter depuis le site vitrine.