### PR TITLE
feat: sélection par défaut des enjeux

### DIFF
--- a/impact/reglementations/models/csrd.py
+++ b/impact/reglementations/models/csrd.py
@@ -81,6 +81,7 @@ class RapportCSRD(TimestampedModel):
                     description=enjeu.description,
                     parent=parent,
                     modifiable=False,
+                    selection=True,
                 )
                 tmp_enjeux.append(ne)
 

--- a/impact/reglementations/tests/test_csrd_views.py
+++ b/impact/reglementations/tests/test_csrd_views.py
@@ -266,8 +266,6 @@ def test_selection_et_deselection_d_enjeux(client, alice, entreprise_non_qualifi
     enjeux = csrd.enjeux.all()
     enjeu_adaptation = enjeux[0]
     enjeu_attenuation = enjeux[1]
-    # enjeu_attenuation.selection = False
-    # enjeu_attenuation.save()
     enjeu_energie = enjeux[2]
     client.force_login(alice)
 
@@ -482,6 +480,7 @@ def test_datapoints_pour_enjeux_non_materiels_au_format_xlsx(
     )
     workbook = load_workbook(filename=BytesIO(response.content))
     noms_onglet = workbook.sheetnames
+
     assert esrs_materielle.replace("_", " ") not in noms_onglet
     assert "Index" in noms_onglet
     assert "ESRS 2" in noms_onglet


### PR DESCRIPTION
Voir : https://trello.com/c/xxZE6tQp/368-passer-la-s%C3%A9lection-des-enjeux-%C3%A0-s%C3%A9lectionn%C3%A9-par-d%C3%A9faut

Tous les enjeux sont sélectionnés par défaut lors de la création d'un
rapport CSRD.

_note_ : 
les anciens rapports CSRD gardent pour l'instant l'ancien
comportement. 
A voir si une migration de données est nécessaire : à confirmer côté métier.
