### PR TITLE
fix: correction de la version de python dans la CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,7 +34,7 @@ jobs:
     - name: Set up python 3.12
       uses: actions/setup-python@v4
       with:
-        python-version: '3.12'
+        python-version: '3.12.8'
         cache: 'pipenv'
     - name: Install pipenv
       run: curl https://raw.githubusercontent.com/pypa/pipenv/master/get-pipenv.py | python


### PR DESCRIPTION
Apparement, la configuration de la CI nécessite de préciser la même
version de Python que celle du `Pipfile`.

Si la version de la CI est plus récente que celle définie pour le
projet, l'installation des dépendances ne s'effectue pas correctement et
la CI échoue.
