### PR TITLE
Ajout du décompte des enjeux dans les tabs

### DIFF
--- a/impact/impact/settings.py
+++ b/impact/impact/settings.py
@@ -70,6 +70,7 @@ MIDDLEWARE = [
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
     "django_hosts.middleware.HostsResponseMiddleware",
     # middlewares touchant à l'utilisation d'HTMX
+    "utils.middlewares.HTMXRequestMiddleware",
     "utils.middlewares.HTMXRetargetMiddleware",
 ]
 ROOT_URLCONF = "impact.urls"

--- a/impact/reglementations/models/csrd.py
+++ b/impact/reglementations/models/csrd.py
@@ -178,6 +178,9 @@ class RapportCSRD(TimestampedModel):
     def nombre_enjeux_selectionnes(self):
         return self.enjeux.filter(selection=True).count()
 
+    def nombre_enjeux_non_selectionnes(self):
+        return self.enjeux.filter(selection=False).count()
+
     def modifiable_par(self, utilisateur: "users.User") -> bool:
         # Vérifie si le rapport CSRD courant est modifiable par un utilisateur donné.
         # tip : un utilisateur anonyme n'a pas d'ID
@@ -207,6 +210,9 @@ class RapportCSRD(TimestampedModel):
 class EnjeuQuerySet(models.QuerySet):
     def selectionnes(self):
         return self.filter(selection=True)
+
+    def non_selectionnes(self):
+        return self.filter(selection=False)
 
     def modifiables(self):
         return self.filter(modifiable=True)

--- a/impact/reglementations/templates/fragments/esrs.html
+++ b/impact/reglementations/templates/fragments/esrs.html
@@ -127,3 +127,6 @@
 <span id="telechargement-xlsx" hx-swap-oob=true>
     {% include "./telechargement_xlsx.html" %}
 </span>
+
+{# et le nombre d'enjeux selectionnés et non-selectionnés (tabs) #}
+{% include "snippets/tab_maj_nombre_enjeux.html" %}

--- a/impact/reglementations/templates/fragments/liste_enjeux_selectionnes.html
+++ b/impact/reglementations/templates/fragments/liste_enjeux_selectionnes.html
@@ -38,7 +38,11 @@
                         <div class="esrs-organizer--esrs">
                             <div class="esrs-organizer--card">
                                 <div class="esrs-organizer--card-title">
-                                    Aucun enjeu sélectionné
+                                    {% if selection %}
+                                        Aucun enjeu sélectionné
+                                    {% else %}
+                                        Tous les enjeux sélectionnés
+                                    {% endif %}
                                 </div>
                             </div>
                         </div>
@@ -78,7 +82,11 @@
                         <div class="esrs-organizer--esrs">
                             <div class="esrs-organizer--card">
                                 <div class="esrs-organizer--card-title">
-                                    Aucun enjeu sélectionné
+                                    {% if selection %}
+                                        Aucun enjeu sélectionné
+                                    {% else %}
+                                        Tous les enjeux sélectionnés
+                                    {% endif %}
                                 </div>
                             </div>
                         </div>
@@ -118,7 +126,11 @@
                         <div class="esrs-organizer--esrs">
                             <div class="esrs-organizer--card">
                                 <div class="esrs-organizer--card-title">
-                                    Aucun enjeu sélectionné
+                                    {% if selection %}
+                                        Aucun enjeu sélectionné
+                                    {% else %}
+                                        Tous les enjeux sélectionnés
+                                    {% endif %}
                                 </div>
                             </div>
                         </div>

--- a/impact/reglementations/templates/fragments/liste_enjeux_selectionnes.html
+++ b/impact/reglementations/templates/fragments/liste_enjeux_selectionnes.html
@@ -22,7 +22,7 @@
                                         {% for enjeu in enjeux %}
                                             <div class="esrs-organizer--table" id="enjeu-selectionne-{{ enjeu.id }}">
                                                 <p class="esrs-organizer--table-cell">{{ enjeu.nom }}</p>
-                                                {% if not csrd.bloque %}
+                                                {% if not csrd.bloque and selection %}
                                                     <div class="esrs-organizer--table-cell col-right">
                                                         <button hx-post="{% url 'reglementations:deselection_enjeu' enjeu.id %}" hx-params="none" hx-target="#enjeu-selectionne-{{ enjeu.id }}" hx-swap="outerHTML" class="fr-icon-delete-bin-line fr-icon--sm col-right" title="Désélectionner cet enjeu" ></button>
                                                     </div>
@@ -62,7 +62,7 @@
                                         {% for enjeu in enjeux %}
                                             <div class="esrs-organizer--table" id="enjeu-selectionne-{{ enjeu.id }}">
                                                 <p class="esrs-organizer--table-cell">{{ enjeu.nom }}</p>
-                                                {% if not csrd.bloque %}
+                                                {% if not csrd.bloque and selection %}
                                                     <div class="esrs-organizer--table-cell col-right">
                                                         <button hx-post="{% url 'reglementations:deselection_enjeu' enjeu.id %}" hx-params="none" hx-target="#enjeu-selectionne-{{ enjeu.id }}" hx-swap="outerHTML" class="fr-icon-delete-bin-line fr-icon--sm col-right" title="Désélectionner cet enjeu"></button>
                                                     </div>
@@ -102,7 +102,7 @@
                                         {% for enjeu in enjeux %}
                                             <div class="esrs-organizer--table" id="enjeu-selectionne-{{ enjeu.id }}">
                                                 <p class="esrs-organizer--table-cell">{{ enjeu.nom }}</p>
-                                                {% if not csrd.bloque %}
+                                                {% if not csrd.bloque and selection %}
                                                     <div class="esrs-organizer--table-cell col-right">
                                                         <button hx-post="{% url 'reglementations:deselection_enjeu' enjeu.id %}" hx-params="none" hx-target="#enjeu-selectionne-{{ enjeu.id }}" hx-swap="outerHTML" class="fr-icon-delete-bin-line fr-icon--sm col-right" title="Désélectionner cet enjeu"></button>
                                                     </div>
@@ -132,5 +132,7 @@
 {% else %}
     <p>Aucun enjeu sélectionné</p>
 {% endif %}
+
+{% include "snippets/tab_maj_nombre_enjeux.html" %}
 
 <!-- fragment liste des enjeux sélectionnés -->

--- a/impact/reglementations/templates/reglementations/csrd/etape-selection-enjeux.html
+++ b/impact/reglementations/templates/reglementations/csrd/etape-selection-enjeux.html
@@ -53,14 +53,20 @@
                     <a class="fr-tabs__tab fr-tabs__tab--icon-left" target="_blank" href="{% url 'reglementations:csrd_sous_etape' entreprise.siren 1 2 2 %}">S'inspirer de standards internationaux</a>
                 </li>
                 <li role="presentation">
-                    <button id="tabpanel-406" class="fr-tabs__tab fr-tabs__tab--icon-left" tabindex="-1" role="tab" aria-selected="false" aria-controls="onglet-liste-enjeux" hx-get="{% url 'reglementations:liste_enjeux_selectionnes' csrd.pk %}" hx-target="#onglet-liste-enjeux">Ma liste d'enjeux à analyser</button>
+                    <button id="tabpanel-selectionnes" class="fr-tabs__tab fr-tabs__tab--icon-left" tabindex="1" role="tab" aria-selected="false" aria-controls="onglet-liste-enjeux-selectionnes" hx-get="{% url 'reglementations:liste_enjeux_selectionnes' csrd.pk 1 %}" hx-target="#onglet-liste-enjeux-selectionnes">(<span id="nb-enjeux-selectionnes">{{ nb_enjeux_selectionnes }}</span>) Ma liste d'enjeux à analyser</button>
+                </li>
+                <li role="presentation">
+                    <button id="tabpanel-non-selectionnes" class="fr-tabs__tab fr-tabs__tab--icon-left" tabindex="-1" role="tab" aria-selected="false" aria-controls="onglet-liste-enjeux-non-selectionnes" hx-get="{% url 'reglementations:liste_enjeux_selectionnes' csrd.pk 0 %}" hx-target="#onglet-liste-enjeux-non-selectionnes">(<span id="nb-enjeux-non-selectionnes">{{ nb_enjeux_non_selectionnes }}</span>) Enjeux exclus</button>
                 </li>
             </ul>
             <div id="onglet-ajout-enjeux" class="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel" aria-labelledby="onglet-ajout-enjeux" tabindex="0">
                 <div class="fr-container fr-pb-6w" id="esg_container"></div>
             </div>
-            <div id="onglet-liste-enjeux" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-406" tabindex="0">
+            <div id="onglet-liste-enjeux-selectionnes" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-selectionnes" tabindex="0">
                 <h4>Enjeux sélectionnés</h4>
+            </div>
+            <div id="onglet-liste-enjeux-non-selectionnes" class="fr-tabs__panel" role="tabpanel" aria-labelledby="tabpanel-non-selectionnes" tabindex="0">
+                <h4>Enjeux non-sélectionnés</h4>
             </div>
         </div>
     </div>

--- a/impact/reglementations/templates/snippets/tab_maj_nombre_enjeux.html
+++ b/impact/reglementations/templates/snippets/tab_maj_nombre_enjeux.html
@@ -1,0 +1,8 @@
+{% if request.htmx %}
+    <span id="nb-enjeux-selectionnes" hx-swap-oob=true>
+        {{ csrd.nombre_enjeux_selectionnes }}
+    </span>
+    <span id="nb-enjeux-non-selectionnes" hx-swap-oob=true>
+        {{ csrd.nombre_enjeux_non_selectionnes }}
+    </span>
+{% endif %}

--- a/impact/reglementations/tests/test_csrd_views.py
+++ b/impact/reglementations/tests/test_csrd_views.py
@@ -389,7 +389,7 @@ def test_liste_des_enjeux_csrd(client, alice, entreprise_non_qualifiee):
     ), "Un des enjeux doit être désélectionné"
 
     client.force_login(alice)
-    response = client.get(f"/csrd/fragments/liste_enjeux_selectionnes/{csrd.id}")
+    response = client.get(f"/csrd/fragments/liste_enjeux_selectionnes/{csrd.id}/1")
 
     assert response.status_code == 200
 

--- a/impact/reglementations/views/fragments/urls.py
+++ b/impact/reglementations/views/fragments/urls.py
@@ -36,7 +36,7 @@ urlpatterns = [
         name="deselection_enjeu",
     ),
     path(
-        "csrd/fragments/liste_enjeux_selectionnes/<int:csrd_id>",
+        "csrd/fragments/liste_enjeux_selectionnes/<int:csrd_id>/<int:selection>",
         liste_enjeux_selectionnes,
         name="liste_enjeux_selectionnes",
     ),

--- a/impact/utils/middlewares.py
+++ b/impact/utils/middlewares.py
@@ -44,3 +44,15 @@ class HTMXRetargetMiddleware:
             response["HX-Retarget"] = new_target
 
         return response
+
+
+class HTMXRequestMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        request.htmx = request.headers.get("HX-Request") == "true"
+
+        response = self.get_response(request)
+
+        return response


### PR DESCRIPTION
Voir #290 

Permettre de voir immédiatement dans les tabs le nombre d'enjeux sélectionnés / non-sélectionnés, et d'avoir le détail pour chaque option.

## Capture d'écran.

![image](https://github.com/user-attachments/assets/5c33a882-7e47-4458-a696-bb3883f23c79)
