### PR TITLE
définition d'une URL canonique

### DIFF
--- a/impact/templates/base.html
+++ b/impact/templates/base.html
@@ -15,6 +15,7 @@
         <link rel="icon" href="{% static 'dsfr/favicon/favicon.svg' %}" type="image/svg+xml">
         <link rel="shortcut icon" href="{% static 'dsfr/favicon/favicon.ico' %}" type="image/x-icon"><!-- 32×32 -->
         <link rel="manifest" href="{% static 'dsfr/favicon/manifest.webmanifest' %}" crossorigin="use-credentials">
+        <link rel="canonical" href="{{ request.scheme }}{{ request.get_host }}{{ request.path }}">
 
         <title>{% block title %}Portail RSE{% endblock %}</title>
 


### PR DESCRIPTION
GSC détecte des URLs dupliquées sur le domaine de cette application de gestion. Cela n'a pas vraiment d'importance car c'est le site vitrine dont on souhaite améliorer le référencement. Je suppose que ce sous-domaine se retrouve référencé car on fusionne les cookies des deux domaines.

Il n'est pas possible d'utiliser simplement `request.get_full_path` dans le template car, dans ce cas, les paramètres GET sont aussi affichés dans l'URL canonique. Le but de la définition de l'URL canonique est les supprimer pour que les différentes URL ne soient plus considérées comme unique mais bien comme la même page.