### PR TITLE
Ajout d'un docker-compose de développement

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,37 @@
+services:
+  # configuration de *développement*
+  db:
+    image: docker.io/scalingo/postgresql
+    command: /postgresql
+    environment:
+       - DB_USER=rse
+       - DB_PASSWORD=rse
+       - DB_ADMIN_PASSWORD=admin
+    volumes:
+      - pgdata:/var/lib/postgresql
+    ports:
+      - "5432:5432"
+
+  redis:
+    image: redis:alpine
+    ports:
+      - "6379:6379"
+    volumes:
+      - redisdata:/data
+
+  minio:
+    image: minio/minio
+    command: server /data --console-address ":9001"
+    environment:
+      MINIO_ROOT_USER: minioadmin
+      MINIO_ROOT_PASSWORD: minioadmin
+    ports:
+      - "9000:9000"
+      - "9001:9001"
+    volumes:
+      - miniodata:/data
+
+volumes:
+  pgdata:
+  redisdata:
+  miniodata:


### PR DESCRIPTION
Pour Minio (S3 local), il est nécessaire d'ajouter une variable d'environnement `SCALEWAY_S3_ENDPOINT_URL` qui pointe vers le serveur local (par défaut : `http://localhost:9001/`)