### PR TITLE
Affichage complet des intitulés des ESRS dans le tableau de synthèse …

### DIFF
--- a/impact/reglementations/tests/tests_csrd/test_analyse_ia_views.py
+++ b/impact/reglementations/tests/tests_csrd/test_analyse_ia_views.py
@@ -284,7 +284,7 @@ def test_telechargement_des_resultats_IA_d_un_document_au_format_xlsx(client, cs
       "TEXTS": "A"
     }
   ],
-  "ESRS E2": [
+  "ESRS E2 : Pollution": [
     {
       "PAGES": 6,
       "TEXTS": "B"
@@ -312,13 +312,13 @@ def test_telechargement_des_resultats_IA_d_un_document_au_format_xlsx(client, cs
     assert onglet["A1"].value == "ESRS"
     assert onglet["B1"].value == "PAGE"
     assert onglet["C1"].value == "PHRASE"
-    assert onglet["A2"].value == "ESRS E1"
+    assert onglet["A2"].value == "ESRS E1 - Changement climatique"
     assert onglet["B2"].value == 1
     assert onglet["C2"].value == "A"
-    assert onglet["A3"].value == "ESRS E2"
+    assert onglet["A3"].value == "ESRS E2 - Pollution"
     assert onglet["B3"].value == 6
     assert onglet["C3"].value == "B"
-    assert onglet["A4"].value == "ESRS E2"
+    assert onglet["A4"].value == "ESRS E2 - Pollution"
     assert onglet["B4"].value == 7
     assert onglet["C4"].value == "C"
     onglet = workbook["Source"]
@@ -396,10 +396,10 @@ def test_telechargement_des_resultats_ia_de_l_ensemble_des_documents_au_format_x
     assert onglet["B1"].value == "FICHIER"
     assert onglet["C1"].value == "PAGE"
     assert onglet["D1"].value == "PHRASE"
-    assert onglet["A2"].value == "ESRS E1"
+    assert onglet["A2"].value == "ESRS E1 - Changement climatique"
     assert onglet["C2"].value == 1
     assert onglet["D2"].value == "A"
-    assert onglet["A3"].value == "ESRS E2"
+    assert onglet["A3"].value == "ESRS E2 - Pollution"
     assert onglet["C3"].value == 6
     assert onglet["D3"].value == "B"
     onglet = workbook["Source"]
@@ -483,10 +483,10 @@ def test_telechargement_des_resultats_par_ESRS_au_format_xlsx(client, csrd):
     assert onglet["B1"].value == "FICHIER"
     assert onglet["C1"].value == "PAGE"
     assert onglet["D1"].value == "PHRASE"
-    assert onglet["A2"].value == "ESRS E2"
+    assert onglet["A2"].value == "ESRS E2 - Pollution"
     assert onglet["C2"].value == 4
     assert onglet["D2"].value == "B"
-    assert onglet["A3"].value == "ESRS E2"
+    assert onglet["A3"].value == "ESRS E2 - Pollution"
     assert onglet["C3"].value == 6
     assert onglet["D3"].value == "C"
     onglet = workbook["Source"]

--- a/impact/reglementations/tests/tests_csrd/test_csrd_views.py
+++ b/impact/reglementations/tests/tests_csrd/test_csrd_views.py
@@ -203,13 +203,13 @@ def test_grouper_phrases_par_esrs(client, csrd):
         rapport_csrd=csrd,
         etat="success",
         resultat_json="""{
-  "ESRS E2": [
+  "ESRS E2 - Pollution": [
     {
       "PAGES": 6,
       "TEXTS": "D"
     }
   ],
-  "ESRS S3": [
+  "ESRS S3 : Communautés affectées": [
     {
       "PAGES": 7,
       "TEXTS": "E"
@@ -233,19 +233,19 @@ def test_grouper_phrases_par_esrs(client, csrd):
         "phrases_environnement": [
             {
                 "nombre_phrases": 2,
-                "titre": "ESRS E1",
+                "titre": "ESRS E1 - Changement climatique",
                 "code_esrs": "E1",
             },
             {
                 "nombre_phrases": 1,
-                "titre": "ESRS E2",
+                "titre": "ESRS E2 - Pollution",
                 "code_esrs": "E2",
             },
         ],
         "phrases_social": [
             {
                 "nombre_phrases": 1,
-                "titre": "ESRS S3",
+                "titre": "ESRS S3 - Communautés affectées",
                 "code_esrs": "S3",
             },
         ],

--- a/impact/reglementations/views/csrd/analyse_ia.py
+++ b/impact/reglementations/views/csrd/analyse_ia.py
@@ -21,6 +21,7 @@ from reglementations.models import DocumentAnalyseIA
 from reglementations.models import RapportCSRD
 from reglementations.views.csrd.csrd import contexte_d_etape
 from reglementations.views.csrd.csrd import xlsx_response
+from reglementations.views.csrd.csrd import normaliser_titre_esrs
 from reglementations.views.csrd.decorators import csrd_required
 from reglementations.views.csrd.decorators import document_required
 
@@ -164,13 +165,17 @@ def _ajoute_ligne_resultat_ia(worksheet, document, avec_nom_fichier, contrainte_
             ):
                 if avec_nom_fichier:
                     ligne = [
-                        esrs,
+                        normaliser_titre_esrs(esrs),
                         document.nom,
                         contenu["PAGES"],
                         contenu["TEXTS"],
                     ]
                 else:
-                    ligne = [esrs, contenu["PAGES"], contenu["TEXTS"]]
+                    ligne = [
+                        normaliser_titre_esrs(esrs),
+                        contenu["PAGES"],
+                        contenu["TEXTS"],
+                    ]
                 worksheet.append(ligne)
 
 

--- a/impact/reglementations/views/csrd/csrd.py
+++ b/impact/reglementations/views/csrd/csrd.py
@@ -28,6 +28,7 @@ from habilitations.models import is_user_attached_to_entreprise
 from reglementations.enums import ESRS
 from reglementations.enums import EtapeCSRD
 from reglementations.enums import ETAPES_CSRD
+from reglementations.enums import TitreESRS
 from reglementations.forms.csrd import DocumentAnalyseIAForm
 from reglementations.forms.csrd import LienRapportCSRDForm
 from reglementations.models import RapportCSRD
@@ -653,17 +654,18 @@ def grouper_phrases_par_esrs(csrd):
                 type_esg = "phrases_social"
             elif esrs.startswith("ESRS G"):
                 type_esg = "phrases_gouvernance"
+            titre_esrs = normaliser_titre_esrs(esrs)
 
-            if esrs in resultat[type_esg]:
-                resultat[type_esg][esrs]["nombre_phrases"] += len(phrases)
+            if titre_esrs in resultat[type_esg]:
+                resultat[type_esg][titre_esrs]["nombre_phrases"] += len(phrases)
             else:
-                resultat[type_esg][esrs] = {
-                    "titre": esrs,
+                resultat[type_esg][titre_esrs] = {
+                    "titre": titre_esrs,
                     "nombre_phrases": len(phrases),
                     "code_esrs": esrs[5:7],
                 }
 
-            esrs_thematiques_detectees.add(esrs)
+            esrs_thematiques_detectees.add(titre_esrs)
             nb_phrases_pertinentes_detectees += len(phrases)
 
     for nom_phase in ("phrases_environnement", "phrases_social", "phrases_gouvernance"):
@@ -674,6 +676,11 @@ def grouper_phrases_par_esrs(csrd):
     resultat["nb_documents_analyses"] = csrd.documents_analyses.count()
     resultat["nb_esrs_thematiques_detectees"] = len(esrs_thematiques_detectees)
     return resultat
+
+
+def normaliser_titre_esrs(titre_esrs):
+    underscored_esrs = titre_esrs[:7].replace(" ", "_")
+    return TitreESRS[underscored_esrs].value
 
 
 def csrd_required_with_enjeux(function):


### PR DESCRIPTION
…et tableurs

L'IA ne retourne que 'ESRS A1' (avec A1 variable selon l'ESRS). Il est donc nécessaire d'ajouter le thème en plus. Le but de n'avoir qu'une information minimale issue de l'IA est de pouvoir modifier facilement les intitulés s'ils changent dans le futur.
Il y a aussi une normalisation des séparateurs si les résultats sont déjà enregistrés en base. Le séparateur utilisé est « - », pour être cohérent avec les tableaux ESG des étapes précédentes.