### PR TITLE
refacto: renommage de fonctions pour être plus homogène

### DIFF
--- a/impact/reglementations/tests/tests_csrd/test_csrd_views.py
+++ b/impact/reglementations/tests/tests_csrd/test_csrd_views.py
@@ -13,7 +13,7 @@ from reglementations.enums import EtapeCSRD
 from reglementations.models.csrd import DocumentAnalyseIA
 from reglementations.models.csrd import Enjeu
 from reglementations.models.csrd import RapportCSRD
-from reglementations.views.csrd.csrd import grouper_phrases_par_esrs
+from reglementations.views.csrd.csrd import resume_resultats_analyse_ia
 
 
 def test_l_espace_csrd_n_est_pas_public(client, alice, entreprise_factory):
@@ -176,7 +176,7 @@ def test_gestion_de_la_csrd(etape, client, alice, entreprise_factory):
     assert len(rapport_csrd.enjeux.all()) == NOMBRE_ENJEUX
 
 
-def test_grouper_phrases_par_esrs(client, csrd):
+def test_resume_resultats_analyse_ia(client, csrd):
     DocumentAnalyseIA.objects.create(
         rapport_csrd=csrd,
         etat="success",
@@ -227,7 +227,7 @@ def test_grouper_phrases_par_esrs(client, csrd):
         rapport_csrd=csrd, etat="error", resultat_json=None
     )
 
-    stats = grouper_phrases_par_esrs(csrd)
+    stats = resume_resultats_analyse_ia(csrd)
 
     assert stats == {
         "phrases_environnement": [

--- a/impact/reglementations/views/csrd/analyse_ia.py
+++ b/impact/reglementations/views/csrd/analyse_ia.py
@@ -20,8 +20,8 @@ from reglementations.forms.csrd import DocumentAnalyseIAForm
 from reglementations.models import DocumentAnalyseIA
 from reglementations.models import RapportCSRD
 from reglementations.views.csrd.csrd import contexte_d_etape
+from reglementations.views.csrd.csrd import normalise_titre_esrs
 from reglementations.views.csrd.csrd import xlsx_response
-from reglementations.views.csrd.csrd import normaliser_titre_esrs
 from reglementations.views.csrd.decorators import csrd_required
 from reglementations.views.csrd.decorators import document_required
 
@@ -165,14 +165,14 @@ def _ajoute_ligne_resultat_ia(worksheet, document, avec_nom_fichier, contrainte_
             ):
                 if avec_nom_fichier:
                     ligne = [
-                        normaliser_titre_esrs(esrs),
+                        normalise_titre_esrs(esrs),
                         document.nom,
                         contenu["PAGES"],
                         contenu["TEXTS"],
                     ]
                 else:
                     ligne = [
-                        normaliser_titre_esrs(esrs),
+                        normalise_titre_esrs(esrs),
                         contenu["PAGES"],
                         contenu["TEXTS"],
                     ]

--- a/impact/reglementations/views/csrd/csrd.py
+++ b/impact/reglementations/views/csrd/csrd.py
@@ -625,7 +625,7 @@ def contexte_d_etape(id_etape, csrd, form=None):
             context |= {
                 "form": form or DocumentAnalyseIAForm(),
                 "documents": csrd.documents,
-                "stats_synthese": grouper_phrases_par_esrs(csrd),
+                "stats_synthese": resume_resultats_analyse_ia(csrd),
                 "onglet_resultats_actif": csrd.documents_analyses.exists()
                 and not csrd.documents_non_analyses.exists(),
             }
@@ -635,7 +635,7 @@ def contexte_d_etape(id_etape, csrd, form=None):
     return context
 
 
-def grouper_phrases_par_esrs(csrd):
+def resume_resultats_analyse_ia(csrd):
     resultat = {
         "phrases_environnement": {},
         "phrases_social": {},
@@ -654,7 +654,7 @@ def grouper_phrases_par_esrs(csrd):
                 type_esg = "phrases_social"
             elif esrs.startswith("ESRS G"):
                 type_esg = "phrases_gouvernance"
-            titre_esrs = normaliser_titre_esrs(esrs)
+            titre_esrs = normalise_titre_esrs(esrs)
 
             if titre_esrs in resultat[type_esg]:
                 resultat[type_esg][titre_esrs]["nombre_phrases"] += len(phrases)
@@ -678,7 +678,7 @@ def grouper_phrases_par_esrs(csrd):
     return resultat
 
 
-def normaliser_titre_esrs(titre_esrs):
+def normalise_titre_esrs(titre_esrs):
     underscored_esrs = titre_esrs[:7].replace(" ", "_")
     return TitreESRS[underscored_esrs].value
 


### PR DESCRIPTION
Commit prévu pour être dans https://github.com/betagouv/portail-rse/pull/432 mais non pushé avant la fusion dans `main`.