### PR TITLE
feat: ajout des éléments techniques de gestion des rôles

### DIFF
--- a/impact/habilitations/context_processors.py
+++ b/impact/habilitations/context_processors.py
@@ -1,0 +1,19 @@
+from .enums import UserRole
+
+
+def habilitation(request):
+    ctx = {}
+    siren_courant = request.session.get("entreprise")
+
+    if not siren_courant:
+        return ctx
+
+    # ajoute l'habilitation de l'utilisateur pour l'entreprise courante
+    # au context sous une forme simplifiée
+    for h in request.habilitations:
+        if h.entreprise.siren == siren_courant:
+            ctx |= {"role_utilisateur": h.role}
+            for role in UserRole.values:
+                ctx |= {f"est_{role}": UserRole.autorise(h.role, role)}
+
+    return ctx

--- a/impact/habilitations/decorators.py
+++ b/impact/habilitations/decorators.py
@@ -1,0 +1,60 @@
+from functools import wraps
+
+from django.http import HttpResponseForbidden
+
+from .enums import UserRole
+from .models import Habilitation
+
+
+def role(*required_roles):
+    """
+    Décorateur pour vérifier que l'utilisateur a une habilitation pour l'entreprise spécifiée
+    et que son rôle satisfait au moins un des rôles requis, en tenant compte de la hiérarchie.
+    """
+
+    def decorateur(view_func):
+        @wraps(view_func)
+        def _wrapped_view(request, *args, **kwargs):
+            # à cette étape, des informations concernant l'utilisateur ont été ajoutées
+            # par le middleware `ExtendUserMiddleware`
+            user = request.user
+            if not user.is_authenticated:
+                return HttpResponseForbidden("L'utilisateur n'est pas authentifié.")
+
+            # la donnée stockée en session est le SIREN de l'entreprise (pas sa PK)
+            siren_entreprise = request.session.get("entreprise")
+            if not siren_entreprise:
+                return HttpResponseForbidden(
+                    "Entreprise manquante pour la vérification des permissions."
+                )
+
+            # on évite une dépendance vers Entreprise
+            entreprise_courante = None
+            for e in user.entreprises:
+                if e.siren == siren_entreprise:
+                    entreprise_courante = e
+                    break
+
+            if not entreprise_courante:
+                return HttpResponseForbidden(
+                    "L'utilisateur n'est pas rattaché à l'entreprise courante."
+                )
+
+            try:
+                habilitation = Habilitation.pour(
+                    entreprise=entreprise_courante, utilisateur=user
+                )
+            except Habilitation.DoesNotExist:
+                return HttpResponseForbidden(
+                    "L'utilisateur n'a pas d'habilitation pour l'entreprise courante."
+                )
+
+            if not UserRole.autorise(habilitation.role, *required_roles):
+                return HttpResponseForbidden("L'utilisateur n'a pas le rôle requis.")
+
+            # Si tout est OK, exécuter la vue originale
+            return view_func(request, *args, **kwargs)
+
+        return _wrapped_view
+
+    return decorateur

--- a/impact/habilitations/decorators.py
+++ b/impact/habilitations/decorators.py
@@ -49,7 +49,9 @@ def role(*required_roles):
                     "L'utilisateur n'a pas d'habilitation pour l'entreprise courante."
                 )
 
-            if not UserRole.autorise(habilitation.role, *required_roles):
+            if habilitation.role and not UserRole.autorise(
+                UserRole(habilitation.role), *required_roles
+            ):
                 return HttpResponseForbidden("L'utilisateur n'a pas le rôle requis.")
 
             # Si tout est OK, exécuter la vue originale

--- a/impact/habilitations/enums.py
+++ b/impact/habilitations/enums.py
@@ -17,6 +17,9 @@ class UserRole(models.TextChoices):
 
     @classmethod
     def autorise(cls, role, *roles):
+        if not role:
+            return False
+
         # définition des "poids" : du plus important au plus faible
         poids = [cls.PROPRIETAIRE, cls.EDITEUR, cls.LECTEUR]
         for r in roles:

--- a/impact/habilitations/enums.py
+++ b/impact/habilitations/enums.py
@@ -2,6 +2,24 @@ from django.db import models
 
 
 class UserRole(models.TextChoices):
+    """
+    Gestion simple (simpliste?) des rôles d'utilisation:
+     - un PROPRIETAIRE possède les droits de LECTEUR et EDITEUR
+     - un EDITEUR a aussi les droits de LECTEUR
+     - un LECTEUR est moins que rien
+    Pourra être remanié au besoin si des besoins plus fins sont nécessaires,
+    le principal est de centraliser l'évaluation des droits.
+    """
+
     PROPRIETAIRE = "proprietaire", "Propriétaire"
     EDITEUR = "editeur", "Éditeur"
     LECTEUR = "lecteur", "Lecteur"
+
+    @classmethod
+    def autorise(cls, role, *roles):
+        # définition des "poids" : du plus important au plus faible
+        poids = [cls.PROPRIETAIRE, cls.EDITEUR, cls.LECTEUR]
+        for r in roles:
+            if poids.index(role) <= poids.index(r):
+                return True
+        return False

--- a/impact/habilitations/enums.py
+++ b/impact/habilitations/enums.py
@@ -1,3 +1,5 @@
+from typing import override
+
 from django.db import models
 
 
@@ -8,21 +10,52 @@ class UserRole(models.TextChoices):
      - un EDITEUR a aussi les droits de LECTEUR
      - un LECTEUR est moins que rien
     Pourra être remanié au besoin si des besoins plus fins sont nécessaires,
-    le principal est de centraliser l'évaluation des droits.
+    le principal est de *centraliser* l'évaluation des droits.
     """
 
     PROPRIETAIRE = "proprietaire", "Propriétaire"
     EDITEUR = "editeur", "Éditeur"
     LECTEUR = "lecteur", "Lecteur"
 
+    @override
+    def __eq__(self, other: "UserRole") -> bool:
+        if not isinstance(other, UserRole):
+            return NotImplemented
+        return self.value == other.value
+
+    # Note :
+    # pour une raison que je ne m'explique pas (encore ?) `@functools.total_ordering` semble ne *pas* fonctionner ici :
+    # - l'implementation automatique de `__lt__` ne donne pas les bons résultats dans les tests (?!)
+    # - `__gt__` ne semble pas mieux fonctionner
+    # Probablement à cause du contexte Django, mais pourquoi ? Sinon c'est un bug en 3.12.x mais j'en doute.
+    # En attendant, je réimplémente toutes les méthodes de comparaison manuellement : les tests passent (!)
+
+    def __lt__(self, other: "UserRole") -> bool:
+        if not isinstance(other, UserRole):
+            return NotImplemented
+        return self._sort_order_ > other._sort_order_
+
+    def __gt__(self, other: "UserRole") -> bool:
+        if not isinstance(other, UserRole):
+            return NotImplemented
+        return self._sort_order_ < other._sort_order_
+
+    def __le__(self, other: "UserRole") -> bool:
+        if not isinstance(other, UserRole):
+            return NotImplemented
+        return self._sort_order_ >= other._sort_order_
+
+    def __ge__(self, other: "UserRole") -> bool:
+        if not isinstance(other, UserRole):
+            return NotImplemented
+        return self._sort_order_ <= other._sort_order_
+
     @classmethod
-    def autorise(cls, role, *roles):
-        if not role:
+    def autorise(cls, role_utilisateur: "UserRole", *roles: "UserRole") -> bool:
+        # vérifie si le rôle utilisateur est supérieur ou égal à un des rôles donnés
+        if not isinstance(role_utilisateur, UserRole) or not all(
+            isinstance(r, UserRole) for r in roles
+        ):
             return False
 
-        # définition des "poids" : du plus important au plus faible
-        poids = [cls.PROPRIETAIRE, cls.EDITEUR, cls.LECTEUR]
-        for r in roles:
-            if poids.index(role) <= poids.index(r):
-                return True
-        return False
+        return any(role_utilisateur >= r for r in roles)

--- a/impact/habilitations/models.py
+++ b/impact/habilitations/models.py
@@ -90,6 +90,53 @@ class Habilitation(TimestampedModel):
     def __str__(self):
         return f"Habilitation : {self.entreprise}, {self.user}, {self.role}"
 
+    def __eq__(self, h):
+        # pour une utilisation avec `in`
+        return (
+            isinstance(h, Habilitation)
+            and self.entreprise_id == h.entreprise_id
+            and self.user_id == h.user_id
+            and self.role == h.role
+        )
+
+    def __hash__(self):
+        # pas de `__eq__` sans `__hash__`
+        # `self.pk` inutile à cause de la contrainte d'intégrité
+        return hash((self.user_id, self.entreprise_id, self.role))
+
+    # comparaisons des habilitations en fonction des rôles
+    # uniquement pour les habilitations d'un même tuple (entreprise,utilisateur)
+
+    def _same_origin(self, other):
+        return (
+            isinstance(other, Habilitation)
+            and self.entreprise == other.entreprise
+            and self.user == other.user
+        )
+
+    # Les méthodes de comparaison suivantes ne sont valides que pour
+    # des habilitations concernant le même utilisateur et la même entreprise.
+
+    def __lt__(self, other):
+        if not self._same_origin(other):
+            return NotImplemented
+        return self.role < other.role
+
+    def __le__(self, other):
+        if not self._same_origin(other):
+            return NotImplemented
+        return self.role <= other.role
+
+    def __gt__(self, other):
+        if not self._same_origin(other):
+            return NotImplemented
+        return self.role > other.role
+
+    def __ge__(self, other):
+        if not self._same_origin(other):
+            return NotImplemented
+        return self.role >= other.role
+
     @classmethod
     def ajouter(
         cls, entreprise, utilisateur, role=UserRole.PROPRIETAIRE, fonctions=None

--- a/impact/habilitations/tests/test_decorators.py
+++ b/impact/habilitations/tests/test_decorators.py
@@ -1,0 +1,78 @@
+from unittest.mock import Mock
+
+import pytest
+from django.http import HttpResponse
+
+from habilitations.decorators import role
+from habilitations.enums import UserRole
+from habilitations.models import Habilitation
+
+# Exemple de vue pour les tests
+def example_view(_):
+    return HttpResponse("OK")
+
+
+@pytest.fixture
+def mock_request(entreprise_non_qualifiee, alice):
+    request = Mock()
+    request.user = alice
+    request.session = {"entreprise": entreprise_non_qualifiee.siren}
+    request.entreprises = [entreprise_non_qualifiee]
+    Habilitation(user=alice, entreprise=entreprise_non_qualifiee).save()
+    return request
+
+
+# Test pour un utilisateur avec le rôle PROPRIETAIRE
+def test_role_proprietaire(mock_request):
+    mock_request.user.role = UserRole.PROPRIETAIRE
+    decorated_view = role(UserRole.PROPRIETAIRE)(example_view)
+    response = decorated_view(mock_request)
+    print(response.content)
+    assert response.status_code == 200
+    assert response.content == b"OK"
+
+
+# Test pour un utilisateur avec le rôle EDITEUR
+def test_role_editeur(mock_request):
+    mock_request.user.role = UserRole.EDITEUR
+    decorated_view = role(UserRole.EDITEUR)(example_view)
+    response = decorated_view(mock_request)
+    assert response.status_code == 200
+    assert response.content == b"OK"
+
+
+# Test pour un utilisateur avec le rôle LECTEUR
+def test_role_lecteur(mock_request):
+    mock_request.user.role = UserRole.LECTEUR
+    decorated_view = role(UserRole.LECTEUR)(example_view)
+    response = decorated_view(mock_request)
+    assert response.status_code == 200
+    assert response.content == b"OK"
+
+
+# Test pour un utilisateur sans les droits nécessaires
+def test_role_forbidden(alice, entreprise_non_qualifiee):
+    mock_request = Mock()
+    mock_request.user = alice
+    mock_request.session = {"entreprise": entreprise_non_qualifiee}
+    Habilitation(
+        user=alice, entreprise=entreprise_non_qualifiee, role=UserRole.LECTEUR
+    ).save()
+
+    mock_request.user.role = UserRole.LECTEUR
+    decorated_view = role(UserRole.PROPRIETAIRE)(example_view)
+    response = decorated_view(mock_request)
+    assert response.status_code == 403
+    assert (
+        response.content
+        == "L'utilisateur n'est pas rattaché à l'entreprise courante.".encode("utf-8")
+    )
+
+
+# Test pour un utilisateur avec un rôle supérieur
+def test_role_superieur(mock_request):
+    mock_request.user.role = UserRole.PROPRIETAIRE
+    decorated_view = role(UserRole.EDITEUR)(example_view)
+    response = decorated_view(mock_request)
+    assert response.status_code == 200
+    assert response.content == b"OK"

--- a/impact/habilitations/tests/test_user_role.py
+++ b/impact/habilitations/tests/test_user_role.py
@@ -1,4 +1,5 @@
 import pytest
+
 from habilitations.enums import UserRole
 
 
@@ -16,7 +17,6 @@ from habilitations.enums import UserRole
         (UserRole.LECTEUR, [UserRole.LECTEUR], True),
         (UserRole.PROPRIETAIRE, [UserRole.EDITEUR, UserRole.LECTEUR], True),
         (UserRole.EDITEUR, [UserRole.PROPRIETAIRE, UserRole.LECTEUR], True),
-        (UserRole.LECTEUR, [UserRole.LECTEUR], True),
     ],
 )
 def test_autorise(role, roles, expected):

--- a/impact/habilitations/tests/test_user_role.py
+++ b/impact/habilitations/tests/test_user_role.py
@@ -1,0 +1,23 @@
+import pytest
+from habilitations.enums import UserRole
+
+
+@pytest.mark.parametrize(
+    "role, roles, expected",
+    [
+        (UserRole.PROPRIETAIRE, [UserRole.PROPRIETAIRE], True),
+        (UserRole.PROPRIETAIRE, [UserRole.EDITEUR], True),
+        (UserRole.PROPRIETAIRE, [UserRole.LECTEUR], True),
+        (UserRole.EDITEUR, [UserRole.PROPRIETAIRE], False),
+        (UserRole.EDITEUR, [UserRole.EDITEUR], True),
+        (UserRole.EDITEUR, [UserRole.LECTEUR], True),
+        (UserRole.LECTEUR, [UserRole.PROPRIETAIRE], False),
+        (UserRole.LECTEUR, [UserRole.EDITEUR], False),
+        (UserRole.LECTEUR, [UserRole.LECTEUR], True),
+        (UserRole.PROPRIETAIRE, [UserRole.EDITEUR, UserRole.LECTEUR], True),
+        (UserRole.EDITEUR, [UserRole.PROPRIETAIRE, UserRole.LECTEUR], True),
+        (UserRole.LECTEUR, [UserRole.LECTEUR], True),
+    ],
+)
+def test_autorise(role, roles, expected):
+    assert UserRole.autorise(role, *roles) == expected

--- a/impact/impact/settings.py
+++ b/impact/impact/settings.py
@@ -89,6 +89,7 @@ TEMPLATES = [
                 "django.contrib.messages.context_processors.messages",
                 "entreprises.context_processors.current_entreprise",
                 "utils.context_processors.custom_settings",
+                "habilitations.context_processors.habilitation",
             ],
         },
     },

--- a/impact/reglementations/forms/csrd.py
+++ b/impact/reglementations/forms/csrd.py
@@ -150,7 +150,7 @@ class EnjeuxMaterielsRapportCSRDForm(forms.Form):
                     ),
                 )
                 # désactivation selon les droits passés par la vue
-                if not UserRole.autorise(role, UserRole.EDITEUR):
+                if role and role < UserRole.EDITEUR:
                     self.fields[f"enjeu_{enjeu.pk}"].widget.attrs["disabled"] = True
 
     def save(self):
@@ -172,7 +172,7 @@ class LienRapportCSRDForm(forms.ModelForm):
         attrs = {"class": "fr-input", "placeholder": "URL du rapport CSRD"}
 
         # désactivation selon les droits passés par la vue
-        if not UserRole.autorise(role, UserRole.EDITEUR):
+        if role and role < UserRole.EDITEUR:
             attrs |= {"disabled": True}
 
         self.fields["lien_rapport"].widget.attrs.update(attrs)

--- a/impact/reglementations/templates/fragments/lien_rapport.html
+++ b/impact/reglementations/templates/fragments/lien_rapport.html
@@ -20,9 +20,11 @@
                     {% csrf_token %}
                     {{ form.lien_rapport }}
                 </div>
-                <div class="fr-col-auto">
-                    <button class="fr-btn fr-icon-checkbox-circle-line fr-btn--icon"></button>
-                </div>
+                {% if est_editeur %}
+                    <div class="fr-col-auto">
+                        <button class="fr-btn fr-icon-checkbox-circle-line fr-btn--icon"></button>
+                    </div>
+                {% endif %}
             </form>
         </div>
 

--- a/impact/reglementations/templates/fragments/selection_enjeux.html
+++ b/impact/reglementations/templates/fragments/selection_enjeux.html
@@ -1,10 +1,12 @@
 {% load random_tools %}
 
-<div class="fr-toggle fr-toggle--label-left">
-    {% uuid as toggle_id %}
-    <input type="checkbox" id="toggle_creation_enjeu_{{ toggle_id }}" class="fr-toggle__input" aria-expanded="false" aria-describedby="toggle-{{ toggle_id }}-messages" aria-controls="creation_enjeu_{{ toggle_id }}">
-    <label class="fr-toggle__label" for="toggle_creation_enjeu_{{ toggle_id }}">Ajouter un enjeu</label>
-</div>
+{% if est_editeur %}
+    <div class="fr-toggle fr-toggle--label-left">
+        {% uuid as toggle_id %}
+        <input type="checkbox" id="toggle_creation_enjeu_{{ toggle_id }}" class="fr-toggle__input" aria-expanded="false" aria-describedby="toggle-{{ toggle_id }}-messages" aria-controls="creation_enjeu_{{ toggle_id }}">
+        <label class="fr-toggle__label" for="toggle_creation_enjeu_{{ toggle_id }}">Ajouter un enjeu</label>
+    </div>
+{% endif %}
 
 <div id="creation_enjeu_{{ toggle_id }}" class="fr-collapse" hx-get="{% url 'reglementations:creation_enjeu' csrd.pk form.esrs %}" hx-trigger="click from:#toggle_creation_enjeu_{{ toggle_id }}" hx-target="this">
     Chargement en cours ...
@@ -27,9 +29,11 @@
             {% endfor %}
         {% endwith %}
     </div>
-    <hr class="fr-mt-6v">
-    <button type="submit" class="fr-btn fr-btn--secondary" hx-disabled-elt="this" aria-controls="modal-{{ form.esrs }}" {% if csrd.bloque %}disabled{% endif %}>
-        Valider
-    </button>
+    {% if est_editeur %}
+        <hr class="fr-mt-6v">
+        <button type="submit" class="fr-btn fr-btn--secondary" hx-disabled-elt="this" aria-controls="modal-{{ form.esrs }}" {% if csrd.bloque %}disabled{% endif %}>
+            Valider
+        </button>
+    {% endif %}
 </form>
 <!-- fragment enjeux -->

--- a/impact/reglementations/templates/fragments/selection_enjeux_materiels.html
+++ b/impact/reglementations/templates/fragments/selection_enjeux_materiels.html
@@ -35,6 +35,7 @@
             <hr>
         </div>
     {% endfor %}
-
-    <button type="submit" class="fr-btn fr-btn--secondary" hx-disabled-elt="this" aria-controls="selection-modal" {% if csrd.bloque %}disabled{% endif %}>Valider</button>
+    {% if est_editeur %}
+        <button type="submit" class="fr-btn fr-btn--secondary" hx-disabled-elt="this" aria-controls="selection-modal" {% if csrd.bloque %}disabled{% endif %}>Valider</button>
+    {% endif %}
 </form>

--- a/impact/reglementations/templates/reglementations/csrd/etape-analyse-ecart.html
+++ b/impact/reglementations/templates/reglementations/csrd/etape-analyse-ecart.html
@@ -42,21 +42,24 @@
                 </li>
             </ul>
             <div id="onglet-fichiers-panel" class="fr-tabs__panel fr-tabs__panel--selected" role="tabpanel" aria-labelledby="onglet-fichiers" tabindex="0">
-                <div>
-                    <form enctype="multipart/form-data" action="{% url 'reglementations:ajout_document' csrd.id %}" method="post">
-                        {% csrf_token %}
-                        {% include 'snippets/field.html' with field=form.fichier %}
-                        <button type="submit" class="fr-btn fr-btn--icon-left fr-icon-upload-2-line fr-mt-1w">Envoyer</button>
-                    </form>
-                </div>
+                {% if est_editeur %}
+                    <div>
+                        <form enctype="multipart/form-data" action="{% url 'reglementations:ajout_document' csrd.id %}" method="post">
+                            {% csrf_token %}
+                            {% include 'snippets/field.html' with field=form.fichier %}
+                            <button type="submit" class="fr-btn fr-btn--icon-left fr-icon-upload-2-line fr-mt-1w">Envoyer</button>
+                        </form>
+                    </div>
 
-                <div class="fr-alert fr-alert--warning fr-my-3w">
-                    <h3 class="fr-alert__title">Veillez à ne pas ajouter de données personnelles.</h3>
-                    <p>
-                        Pour plus d'informations, veuillez consulter
-                        <a title="Voir les Conditions Générales d'Utilisation" href="{{ sites_faciles_base_url }}/conditions-generales-d-utilisation/" target="_blank">nos Conditions Générales d'Utilisation</a>
-                    </p>
-                </div>
+                    <div class="fr-alert fr-alert--warning fr-my-3w">
+                        <h3 class="fr-alert__title">Veillez à ne pas ajouter de données personnelles.</h3>
+                        <p>
+                            Pour plus d'informations, veuillez consulter
+                            <a title="Voir les Conditions Générales d'Utilisation" href="{{ sites_faciles_base_url }}/conditions-generales-d-utilisation/" target="_blank">nos Conditions Générales d'Utilisation</a>
+                        </p>
+                    </div>
+                {% endif %}
+
                 {% if documents.count %}
                     <div class="fr-table" id="table-md-component">
                         <div class="fr-table__wrapper">
@@ -126,12 +129,17 @@
                                                             <li>
                                                                 <a class="fr-btn fr-btn--secondary fr-icon-external-link-line" title="Voir le document dans un nouvel onglet" href="{{ document.fichier.url }}" target="_blank">Voir le document dans un nouvel onglet</a>
                                                             </li>
-                                                            <li>
-                                                                <form action="{% url 'reglementations:suppression_document' document.id %}" method="post">
-                                                                    {% csrf_token %}
-                                                                    <button type="submit" class="fr-btn fr-btn--secondary fr-icon-delete-line" title="Supprimer le document">Supprimer le document</button>
-                                                                </form>
-                                                            </li>
+                                                            {% if est_editeur %}
+                                                                <li>
+                                                                    <form action="{% url 'reglementations:suppression_document' document.id %}" method="post">
+                                                                        {% csrf_token %}
+                                                                        <button type="submit" class="fr-btn fr-btn--secondary fr-icon-delete-line" title="Supprimer le document">Supprimer le document</button>
+                                                                    </form>
+                                                                </li>
+                                                            {% else %}
+							            {# Une répétition est parfois plus claire qu'un fragment dynamique #}
+                                                                <button disabled type="button" class="fr-btn fr-btn--secondary fr-icon-delete-line" title="Supprimer le document">Supprimer le document</button>
+                                                            {% endif %}
                                                         </ul>
                                                     </td>
                                                 </tr>

--- a/impact/reglementations/templates/snippets/csrd_submit.html
+++ b/impact/reglementations/templates/snippets/csrd_submit.html
@@ -1,10 +1,12 @@
-<div class="csrd-action fr-py-4w">
-    <div class="fr-container">
-        <div class="fr-grid-row fr-grid-row--right">
-            <form action="{% url 'reglementations:gestion_csrd' entreprise.siren etape.id %}" method="post">
-                {% csrf_token %}
-                <button type="submit" name="save_complete" class="fr-btn fr-btn--icon-left fr-icon-checkbox-circle-line">Enregistrer et marquer comme terminé</button>
-            </form>
+{% if est_editeur %}
+    <div class="csrd-action fr-py-4w">
+        <div class="fr-container">
+            <div class="fr-grid-row fr-grid-row--right">
+                <form action="{% url 'reglementations:gestion_csrd' entreprise.siren etape.id %}" method="post">
+                    {% csrf_token %}
+                    <button type="submit" name="save_complete" class="fr-btn fr-btn--icon-left fr-icon-checkbox-circle-line">Enregistrer et marquer comme terminé</button>
+                </form>
+            </div>
         </div>
     </div>
-</div>
+{% endif %}

--- a/impact/reglementations/templates/widgets/enjeu_option.html
+++ b/impact/reglementations/templates/widgets/enjeu_option.html
@@ -4,7 +4,9 @@
     <div class="selection-enjeu fr-mt-2v">
         <div class="selection-enjeu_label">
             <label for="input-{{ widget_uuid }}">
-                <input type="checkbox" name="{{ widget.name }}" id="input-{{ widget_uuid }}" value="{{ widget.value }}" {% if widget.selected %}checked{% endif %}>
+                {% if widget.est_editeur %}
+                    <input type="checkbox" name="{{ widget.name }}" id="input-{{ widget_uuid }}" value="{{ widget.value }}" {% if widget.selected %}checked{% endif %}>
+                {% endif %}
                 <span class="fr-pl-1v grow">
                     {% if enjeu.parent %}
                         {{ widget.label }}

--- a/impact/reglementations/views/csrd/fragments/enjeux.py
+++ b/impact/reglementations/views/csrd/fragments/enjeux.py
@@ -1,6 +1,7 @@
 """
 Fragments HTMX pour la sélection des enjeux par ESRS
 """
+
 import logging
 
 from django.contrib.auth.decorators import login_required
@@ -10,6 +11,7 @@ from django.shortcuts import reverse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods
 
+from habilitations.models import Habilitation
 import utils.htmx as htmx
 from habilitations.enums import UserRole
 from reglementations.enums import ESRS
@@ -43,12 +45,11 @@ def selection_enjeux(request, csrd_id, esrs):
         "csrd": csrd,
         "htmx": True,
     }
-    est_editeur = bool(
-        [
-            h
-            for h in request.habilitations
-            if (h.entreprise == csrd.entreprise and h.role == UserRole.EDITEUR)
-        ]
+    est_editeur = (
+        Habilitation(
+            entreprise=csrd.entreprise, user=request.user, role=UserRole.EDITEUR
+        )
+        in request.habilitations
     )
 
     if request.method == "GET":

--- a/impact/reglementations/views/csrd/fragments/enjeux.py
+++ b/impact/reglementations/views/csrd/fragments/enjeux.py
@@ -11,6 +11,7 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods
 
 import utils.htmx as htmx
+from habilitations.enums import UserRole
 from reglementations.enums import ESRS
 from reglementations.enums import ThemeESRS
 from reglementations.enums import TitreESRS
@@ -42,12 +43,24 @@ def selection_enjeux(request, csrd_id, esrs):
         "csrd": csrd,
         "htmx": True,
     }
+    est_editeur = bool(
+        [
+            h
+            for h in request.habilitations
+            if (h.entreprise == csrd.entreprise and h.role == UserRole.EDITEUR)
+        ]
+    )
 
     if request.method == "GET":
         return render(
             request,
             template_name="fragments/selection_enjeux.html",
-            context=context | {"form": EnjeuxRapportCSRDForm(instance=csrd, esrs=esrs)},
+            context=context
+            | {
+                "form": EnjeuxRapportCSRDForm(
+                    instance=csrd, esrs=esrs, est_editeur=est_editeur
+                )
+            },
         )
 
     # Dans un fragment, l'utilisation du Post/Redirect/Get n'est pas nécessaire (XHR)

--- a/impact/reglementations/views/csrd/fragments/enjeux.py
+++ b/impact/reglementations/views/csrd/fragments/enjeux.py
@@ -1,7 +1,6 @@
 """
 Fragments HTMX pour la sélection des enjeux par ESRS
 """
-
 import logging
 
 from django.contrib.auth.decorators import login_required
@@ -11,9 +10,9 @@ from django.shortcuts import reverse
 from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_http_methods
 
-from habilitations.models import Habilitation
 import utils.htmx as htmx
 from habilitations.enums import UserRole
+from habilitations.models import Habilitation
 from reglementations.enums import ESRS
 from reglementations.enums import ThemeESRS
 from reglementations.enums import TitreESRS
@@ -46,10 +45,8 @@ def selection_enjeux(request, csrd_id, esrs):
         "htmx": True,
     }
     est_editeur = (
-        Habilitation(
-            entreprise=csrd.entreprise, user=request.user, role=UserRole.EDITEUR
-        )
-        in request.habilitations
+        Habilitation.pour(entreprise=csrd.entreprise, utilisateur=request.user).role
+        == UserRole.EDITEUR
     )
 
     if request.method == "GET":

--- a/impact/reglementations/views/csrd/fragments/enjeux_materiels.py
+++ b/impact/reglementations/views/csrd/fragments/enjeux_materiels.py
@@ -77,15 +77,21 @@ def selection_enjeux_materiels(request, csrd_id, esrs):
         "theme": ThemeESRS[esrs].value,
         "titre": TitreESRS[esrs].value,
     }
+    # On ajoute le rôle de l'utilisateur au formulaire
+    if roles := [
+        h.role for h in request.habilitations if h.entreprise == csrd.entreprise
+    ]:
+        [role] = roles
 
     if request.method == "GET":
         return render(
             request,
             template_name=template_name,
-            context=context | {"form": EnjeuxMaterielsRapportCSRDForm(qs=qs)},
+            context=context
+            | {"form": EnjeuxMaterielsRapportCSRDForm(qs=qs, role=role)},
         )
 
-    form = EnjeuxMaterielsRapportCSRDForm(request.POST, qs=qs)
+    form = EnjeuxMaterielsRapportCSRDForm(request.POST, qs=qs, role=role)
 
     if form.is_valid() and not csrd.bloque:
         form.save()

--- a/impact/utils/middlewares.py
+++ b/impact/utils/middlewares.py
@@ -7,6 +7,13 @@ class ExtendUserMiddleware:
         self.get_response = get_response
 
     def __call__(self, request):
+        # en requête plutôt qu'en session :
+        # - overhead minime
+        # - pas de serialisation nécessaire
+        # - utilisation des habilitations omniprésente désormais
+        request.habilitations = []
+        request.entreprises = []
+
         if request.user.is_authenticated:
             # on ajoute les habilitations et les entreprises de l'utilisateur
             # pour éviter d'effectuer des requêtes supplementaires
@@ -14,6 +21,9 @@ class ExtendUserMiddleware:
             request.user = User.objects.prefetch_related(
                 "entreprise_set", "habilitation_set"
             ).get(pk=request.user.pk)
+            # on ajoute des raccourcis vers les habilitations et entreprises de l'utilisateur
+            request.habilitations = request.user.habilitation_set.all()
+            request.entreprises = request.user.entreprise_set.all()
 
         response = self.get_response(request)
 


### PR DESCRIPTION
A la suite de #456 et #468 

Ajout des éléments techniques pour gérer les habilitations : 
- décorateur pour les vues 
- variables de contexte pour les templates
- quelques méthodes utilitaires sur `Habilitation` et `UserRole` pour une intégration plus facile

