### PR TITLE
suppression d'un warning émis par django-vite

### DIFF
--- a/impact/impact/settings.py
+++ b/impact/impact/settings.py
@@ -190,11 +190,15 @@ COOKIE_DOMAIN = os.getenv("COOKIE_DOMAIN", "")
 
 # Django-vite configuration for static files build with vite
 # https://github.com/MrBin99/django-vite
-DJANGO_VITE_ASSETS_PATH = Path(BASE_DIR, "static", "svelte")
-DJANGO_VITE_DEV_MODE = DEBUG
-DJANGO_VITE_MANIFEST_PATH = Path(DJANGO_VITE_ASSETS_PATH, "manifest.json")
-DJANGO_VITE_DEV_SERVER_PORT = 5173
-DJANGO_VITE_STATIC_URL_PREFIX = "svelte"
+DJANGO_VITE = {
+    "default": {
+        "dev_mode": DEBUG,
+        "manifest_path": Path(BASE_DIR, "static/svelte/manifest.json"),
+        "dev_server_port": 5173,
+        "static_url_prefix": "svelte",
+    }
+}
+
 
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/4.1/howto/static-files/


### PR DESCRIPTION
La mise-à-jour de la façon de configurer django-vite permet d'éliminer ce warning : 

> [...]/site-packages/django_vite/core/asset_loader.py:752: DeprecationWarning: The settings [DJANGO_VITE_DEV_MODE, DJANGO_VITE_DEV_SERVER_PORT, DJANGO_VITE_STATIC_URL_PREFIX, DJANGO_VITE_MANIFEST_PATH, DJANGO_VITE_ASSETS_PATH] will be removed in future releases of django-vite. Please switch to defining your settings as DJANGO_VITE = {"default": {...},}.

La constante `DJANGO_VITE_ASSETS_PATH` disparait car elle n'est plus utilisée dans la bibliothèque django-vite : 
https://github.com/MrBin99/django-vite/blob/c6df9f5ab4d3aac8481abfcca010e2faa9653554/django_vite/core/asset_loader.py#L682