### PR TITLE
Ajout d'une URL redirigeant vers l'analyse d'écart sans variable

### DIFF
--- a/impact/reglementations/views/csrd/csrd.py
+++ b/impact/reglementations/views/csrd/csrd.py
@@ -498,7 +498,9 @@ def gestion_csrd(request, siren=None, id_etape="introduction"):
                 "Commencez par ajouter une entreprise à votre compte utilisateur avant d'accéder à l'espace Rapport de Durabilité",
             )
             return redirect("entreprises:entreprises")
-        return redirect("reglementations:csrd", siren=entreprise.siren)
+        return redirect(
+            "reglementations:gestion_csrd", siren=entreprise.siren, id_etape=id_etape
+        )
 
     entreprise = get_object_or_404(Entreprise, siren=siren)
     if not is_user_attached_to_entreprise(request.user, entreprise):

--- a/impact/reglementations/views/csrd/urls.py
+++ b/impact/reglementations/views/csrd/urls.py
@@ -15,6 +15,11 @@ from reglementations.views.csrd.csrd import gestion_csrd
 
 urlpatterns = [
     path(
+        "csrd/etape-<str:id_etape>",
+        gestion_csrd,
+        name="gestion_csrd",
+    ),
+    path(
         "csrd/<str:siren>/etape-<str:id_etape>",
         gestion_csrd,
         name="gestion_csrd",


### PR DESCRIPTION
Cela permet d'insérer un lien sur le site vitrine permettant d'afficher l'étape analyse d'écart du rapport de durabilité sur le site de gestion.

Le comportement est similaire au tableau de bord où l'URL /tableau-de-bord permet d'arriver sur le tableau de bord de l'utilisateur grâce à des redirections.

close #461 