### PR TITLE
fix: réparation du menu de l'espace CSRD

### DIFF
--- a/impact/reglementations/templates/snippets/csrd_menu.html
+++ b/impact/reglementations/templates/snippets/csrd_menu.html
@@ -4,7 +4,7 @@
             <button class="fr-sidemenu__btn" hidden aria-controls="fr-sidemenu-wrapper" aria-expanded="false">Dans cette rubrique</button>
             <div class="fr-collapse" id="fr-sidemenu-wrapper">
                 <ul class="fr-sidemenu__list">
-                    {% for step in etapes %}
+                    {% for step in steps %}
                         {% if step.sous_etapes %}
                             <li class="fr-sidemenu__item">
                                 <button


### PR DESCRIPTION
A cause d'une modification sur un fichier de menu similaire à celui des VSME 
(qui n'avait d'ailleurs rien à faire dans la PR : on l'a loupé à la revue).
