### PR TITLE
fix: modifications mineures partage des droits

### DIFF
--- a/impact/reglementations/tests/tests_csrd/test_analyse_ia_views.py
+++ b/impact/reglementations/tests/tests_csrd/test_analyse_ia_views.py
@@ -6,10 +6,7 @@ from django.urls import reverse
 from openpyxl import load_workbook
 
 from api.exceptions import APIError
-from habilitations.models import Habilitation
 from reglementations.models.csrd import DocumentAnalyseIA
-from reglementations.models.csrd import RapportCSRD
-from reglementations.views.csrd.analyse_ia import envoie_resultat_ia_email
 
 CONTENU_PDF = b"%PDF-1.4\n%\xd3\xeb\xe9\xe1\n1 0 obj\n<</Title (CharteEngagements"
 
@@ -214,7 +211,9 @@ def test_serveur_IA_envoie_l_etat_d_avancement_de_l_analyse_2(
     assert mail.template_id == settings.BREVO_RESULTAT_ANALYSE_IA_TEMPLATE
 
 
-def test_serveur_IA_envoie_le_resultat_de_l_analyse(client, document, mailoutbox, alice):
+def test_serveur_IA_envoie_le_resultat_de_l_analyse(
+    client, document, mailoutbox, alice
+):
     RESULTATS = """{
   "ESRS E1": [
     {
@@ -298,7 +297,9 @@ def test_envoie_resultat_ia_email_non_bloquant(client, document, mocker):
     assert isinstance(args[0], Exception)
 
 
-def test_telechargement_des_resultats_IA_d_un_document_au_format_xlsx(client, csrd, alice):
+def test_telechargement_des_resultats_IA_d_un_document_au_format_xlsx(
+    client, csrd, alice
+):
     document = DocumentAnalyseIA.objects.create(
         rapport_csrd=csrd,
         etat="success",

--- a/impact/reglementations/tests/tests_csrd/test_csrd_fragments.py
+++ b/impact/reglementations/tests/tests_csrd/test_csrd_fragments.py
@@ -9,23 +9,21 @@ Fragments HTMX pour la gestion de l'espace CSRD
 """
 
 
-def _rapport_csrd_officiel(entreprise_non_qualifiee, alice, annee=now().year):
+def _rapport_csrd(entreprise_non_qualifiee, alice, annee=now().year):
     entreprise_non_qualifiee.users.add(alice)
-    rapport = RapportCSRD(
-        entreprise=entreprise_non_qualifiee, proprietaire=None, annee=annee
-    )
+    rapport = RapportCSRD(entreprise=entreprise_non_qualifiee, annee=annee)
     rapport.save()
     return rapport
 
 
 @pytest.fixture
 def rapport_csrd_courant(entreprise_non_qualifiee, alice):
-    return _rapport_csrd_officiel(entreprise_non_qualifiee, alice)
+    return _rapport_csrd(entreprise_non_qualifiee, alice)
 
 
 @pytest.fixture
 def rapport_csrd_precedent(entreprise_non_qualifiee, alice):
-    return _rapport_csrd_officiel(entreprise_non_qualifiee, alice, annee=now().year - 1)
+    return _rapport_csrd(entreprise_non_qualifiee, alice, annee=now().year - 1)
 
 
 def test_soumission_lien_rapport(client, rapport_csrd_courant, alice):

--- a/impact/reglementations/tests/tests_csrd/test_csrd_models.py
+++ b/impact/reglementations/tests/tests_csrd/test_csrd_models.py
@@ -1,26 +1,9 @@
-from datetime import datetime
-
 import pytest
 from django.core.exceptions import ValidationError
 
-from habilitations.models import Habilitation
 from reglementations.enums import ENJEUX_NORMALISES
 from reglementations.models import DocumentAnalyseIA
 from reglementations.models import RapportCSRD
-
-# Fixtures :
-# voir pour pull-up éventuel, au besoin
-
-
-@pytest.fixture
-def rapport_officiel(alice, entreprise_non_qualifiee):
-    # Alice est habilitée à modifier ce rapport officiel
-    entreprise_non_qualifiee.users.add(alice)
-    return RapportCSRD.objects.create(
-        proprietaire=None,
-        entreprise=entreprise_non_qualifiee,
-        annee=f"{datetime.now():%Y}",
-    )
 
 
 def test_impossible_de_creer_plusieurs_rapports_officiels_pour_les_mêmes_entreprise_et_annee(
@@ -57,10 +40,10 @@ def test_possible_de_creer_plusieurs_rapports_officiels_pour_des_annees_differen
     )
 
 
-def test_enjeux_normalises_presents(rapport_officiel):
+def test_enjeux_normalises_presents(csrd):
     # les enjeux normalisés doivent être présents sur un nouveau rapport CSRD
     ENJEU_CHANGEMENT_CLIMATIQUE = ENJEUX_NORMALISES[0]
-    enjeu = rapport_officiel.enjeux.order_by("id")[0]
+    enjeu = csrd.enjeux.order_by("id")[0]
     nom, esrs, description = enjeu.nom, enjeu.esrs, enjeu.description
     assert (nom, esrs, description) == (
         ENJEU_CHANGEMENT_CLIMATIQUE.nom,
@@ -70,11 +53,11 @@ def test_enjeux_normalises_presents(rapport_officiel):
     assert not enjeu.parent
 
     ENJEU_RESSOURCES_MARINES = ENJEUX_NORMALISES[10]
-    enjeu_ressources_marines = rapport_officiel.enjeux.order_by("id")[10]
+    enjeu_ressources_marines = csrd.enjeux.order_by("id")[10]
     assert not enjeu_ressources_marines.parent
 
     ENJEU_CONSOMMATION_EAU = ENJEU_RESSOURCES_MARINES.children[0]
-    enjeu_consommation_eau = rapport_officiel.enjeux.order_by("id")[11]
+    enjeu_consommation_eau = csrd.enjeux.order_by("id")[11]
     nom, esrs, description = (
         enjeu_consommation_eau.nom,
         enjeu_consommation_eau.esrs,
@@ -88,59 +71,43 @@ def test_enjeux_normalises_presents(rapport_officiel):
     assert enjeu_consommation_eau.parent == enjeu_ressources_marines
 
 
-def test_rapport_csrd_modifiable_par(rapport_officiel, alice, bob):
-    # un rapport officiel n'est modifiable que par les utilisateurs habilités de l'entreprise
+def test_rapport_csrd_bloque_non_modifiable(csrd):
+    csrd.description = "Description modifiée"
 
-    # on s'assure qu'Alice est bien habilitée
-    assert Habilitation.existe(
-        entreprise=rapport_officiel.entreprise, utilisateur=alice
-    ), "Le rapport CSRD doit être modifiable par Alice"
-
-    # et pas Bob
-    assert not Habilitation.existe(
-        entreprise=rapport_officiel.entreprise, utilisateur=bob
-    ), "Le rapport CSRD ne doit pas être modifiable par Bob"
-
-
-def test_rapport_csrd_bloque_non_modifiable(rapport_officiel):
-    rapport_officiel.description = "Description modifiée"
-
-    rapport_officiel.save()
-    rapport_officiel.refresh_from_db()
+    csrd.save()
+    csrd.refresh_from_db()
 
     assert (
-        rapport_officiel.description == "Description modifiée"
+        csrd.description == "Description modifiée"
     ), "Le rapport CSRD doit être modifiable (non-bloqué)"
 
     # vérifie que le rapport CSRD n'est plus modifiable après publication du rapport
-    rapport_officiel.bloque = True
-    rapport_officiel.lien_rapport = "https://exemple.com/rapport"
+    csrd.bloque = True
+    csrd.lien_rapport = "https://exemple.com/rapport"
 
-    initial_description = rapport_officiel.description
+    initial_description = csrd.description
 
     # tente de modifier le rapport sur des champs bloqués
-    rapport_officiel.description = "Nouvelle description"
-    rapport_officiel.lien_rapport = "https://example.com/nouveau"
+    csrd.description = "Nouvelle description"
+    csrd.lien_rapport = "https://example.com/nouveau"
 
-    rapport_officiel.save()
-    rapport_officiel.refresh_from_db()
+    csrd.save()
+    csrd.refresh_from_db()
 
     assert (
-        rapport_officiel.description == initial_description
+        csrd.description == initial_description
     ), "Le rapport CSRD ne devrait pas être modifié (bloqué)"
     assert (
-        rapport_officiel.lien_rapport == "https://example.com/nouveau"
+        csrd.lien_rapport == "https://example.com/nouveau"
     ), "Seul le lien_rapport devrait être modifiable"
 
 
-def test_rapport_csrd_avec_documents(rapport_officiel):
-    document_1 = DocumentAnalyseIA.objects.create(rapport_csrd=rapport_officiel)
-    document_2 = DocumentAnalyseIA.objects.create(
-        rapport_csrd=rapport_officiel, etat="pending"
-    )
+def test_rapport_csrd_avec_documents(csrd):
+    document_1 = DocumentAnalyseIA.objects.create(rapport_csrd=csrd)
+    document_2 = DocumentAnalyseIA.objects.create(rapport_csrd=csrd, etat="pending")
 
-    assert list(rapport_officiel.documents_analyses) == []
-    assert list(rapport_officiel.documents_non_analyses) == [document_1]
+    assert list(csrd.documents_analyses) == []
+    assert list(csrd.documents_non_analyses) == [document_1]
     assert document_1.nombre_de_phrases_pertinentes == 0
     assert document_2.nombre_de_phrases_pertinentes == 0
 
@@ -171,5 +138,5 @@ def test_rapport_csrd_avec_documents(rapport_officiel):
     }"""
     document_2.save()
 
-    assert list(rapport_officiel.documents_analyses) == [document_2]
+    assert list(csrd.documents_analyses) == [document_2]
     assert document_2.nombre_de_phrases_pertinentes == 3

--- a/impact/reglementations/tests/tests_csrd/test_csrd_views.py
+++ b/impact/reglementations/tests/tests_csrd/test_csrd_views.py
@@ -61,7 +61,6 @@ def test_gestion_de_la_csrd(etape, client, alice, entreprise_factory):
             response, "reglementations/csrd/etape-redaction-rapport-durabilite.html"
         )
 
-    # note : plus de rapport personnels => pas de proprietaire
     rapport_csrd = RapportCSRD.objects.get(entreprise=entreprise)
     NOMBRE_ENJEUX = 103
     assert len(rapport_csrd.enjeux.all()) == NOMBRE_ENJEUX

--- a/impact/reglementations/views/bdese.py
+++ b/impact/reglementations/views/bdese.py
@@ -316,12 +316,10 @@ def bdese_step(request, siren, annee, step):
     # les lecteurs et éditeurs ne sont pas habilités à créer une BDESE
     if role == UserRole.PROPRIETAIRE:
         bdese, _ = classe_bdese.objects.get_or_create(
-            entreprise=entreprise, annee=annee, user=None
+            entreprise=entreprise, annee=annee
         )
     else:
-        bdese = classe_bdese.objects.filter(
-            entreprise=entreprise, annee=annee, user=None
-        )
+        bdese = classe_bdese.objects.filter(entreprise=entreprise, annee=annee)
         if not bdese.exists():
             messages.warning(
                 request,


### PR DESCRIPTION
Essentiellement quelques morceaux de revues sur les tests en provenance de #542.
Objectif : ne plus toucher pour l'instant la PR #542 déjà conséquente et poussée en recette.

- **fix: suppression du paramètre `user` pour la création de BDESE**
- **fix: suppression d'une fixture inutile**
- **fix: modifications mineures de quelques tests**
