### PR TITLE
fix: supprime tous les mtm_campaign des liens internes de l'app

### DIFF
--- a/impact/public/templates/public/index.html
+++ b/impact/public/templates/public/index.html
@@ -24,7 +24,7 @@
                     {% if user.is_authenticated and current_entreprise %}
                         <a href="{% url 'reglementations:tableau_de_bord' current_entreprise.siren %}" class="fr-btn fr-btn--lg">Accéder à mon tableau de bord</a>
                     {% else %}
-                        <a href="{% url 'simulation' %}?mtm_campaign=simulation-cta-principal&mtm_kwd=corps-page" class="fr-btn fr-btn--lg">Vérifier mes obligations en 30 sec</a>
+                        <a href="{% url 'simulation' %}" class="fr-btn fr-btn--lg">Vérifier mes obligations en 30 sec</a>
                     {% endif %}
                 </div>
             </div>
@@ -41,7 +41,7 @@
                             <div class="fr-card__footer">
                                 <ul class="fr-btns-group">
                                     <li>
-                                        <a href="{% url 'simulation' %}?mtm_campaign=simulation-carte&mtm_kwd=corps-page" class="fr-btn fr-btn--secondary">
+                                        <a href="{% url 'simulation' %}" class="fr-btn fr-btn--secondary">
                                             Vérifier mes obligations
                                         </a>
                                     </li>
@@ -100,7 +100,7 @@
                                                 Piloter mes obligations
                                             </a>
                                         {% else %}
-                                            <a href="{% url 'users:login' %}?next={{ request.path }}&mtm_campaign=obligations-carte&mtm_kwd=corps-page" class="fr-btn fr-btn--secondary">
+                                            <a href="{% url 'users:login' %}?next={{ request.path }}" class="fr-btn fr-btn--secondary">
                                                 Piloter mes obligations
                                             </a>
                                         {% endif %}
@@ -231,7 +231,7 @@
                 </div>
             </div>
             <div class="fr-grid-row fr-grid-row--center">
-                <a href="{% url 'simulation' %}?mtm_campaign=simulation-bloc-rse&mtm_kwd=corps-page" class="fr-btn fr-btn--primary">
+                <a href="{% url 'simulation' %}" class="fr-btn fr-btn--primary">
                     Vérifier mes obligations en 30 secondes
                 </a>
             </div>

--- a/impact/public/templates/public/resultats_simulation.html
+++ b/impact/public/templates/public/resultats_simulation.html
@@ -8,7 +8,7 @@
         <div class="fr-container">
             <div class="fr-grid-row fr-py-4w">
                 <div class="fr-col-12">
-                    <a class="fr-link fr-icon-draft-fill fr-link--icon-left" href="{% url 'simulation' %}?mtm_campaign=simulation-nouvelle-simulation&mtm_kwd=corps-page">Modifier ma simulation</a>
+                    <a class="fr-link fr-icon-draft-fill fr-link--icon-left" href="{% url 'simulation' %}">Modifier ma simulation</a>
                 </div>
             </div>
             <div class="fr-grid-row fr-grid-row--top fr-pb-8w">
@@ -79,7 +79,7 @@
                                 <p>Accédez à votre tableau de bord pour piloter vos potentielles futures réglementations.</p>
                             {% endif %}
                         {% endif %}
-                        <a class="fr-btn" href="{% url 'reglementations:tableau_de_bord' siren %}?mtm_campaign=simulation-bloc-pilotage&mtm_kwd=corps-page">C'est parti !</a>
+                        <a class="fr-btn" href="{% url 'reglementations:tableau_de_bord' siren %}">C'est parti !</a>
                     </div>
                 </div>
             </div>

--- a/impact/public/templates/public/simulation.html
+++ b/impact/public/templates/public/simulation.html
@@ -14,7 +14,7 @@
                             <p>
                                 Effectuez une simulation simplifiée pour connaître les réglementations applicables à votre entreprise.<br>
                                 {% if not user.is_authenticated %}
-                                    <a href="{% url 'users:creation' %}" target="_self" class="fr-link">Inscrivez-vous</a> ou <a href="{% url 'users:login' %}?mtm_campaign=connexion-simulation&mtm_kwd=corps-page" target="_self" class="fr-link">connectez-vous</a> pour saisir vos critères complets.
+                                    <a href="{% url 'users:creation' %}" target="_self" class="fr-link">Inscrivez-vous</a> ou <a href="{% url 'users:login' %}" target="_self" class="fr-link">connectez-vous</a> pour saisir vos critères complets.
                                 {% endif %}
                             </p>
 

--- a/impact/templates/snippets/entete_page.html
+++ b/impact/templates/snippets/entete_page.html
@@ -48,9 +48,9 @@
                                 </div>
                             </li>
                         {% else %}
-                            <li><a class="fr-btn fr-btn--secondary fr-icon-lock-fill" href="{% absolute_url 'users:login' %}?mtm_campaign=connexion-menu&mtm_kwd=menu">Se connecter</a></li>
+                            <li><a class="fr-btn fr-btn--secondary fr-icon-lock-fill" href="{% absolute_url 'users:login' %}">Se connecter</a></li>
                             {% if url_simulation not in request.path %}
-                                <li><a class="fr-btn fr-btn--primary fr-btn--tool-links" href="{% absolute_url 'simulation' %}?mtm_campaign=simulation-menu&mtm_kwd=menu">Vérifier mes obligations</a></li>
+                                <li><a class="fr-btn fr-btn--primary fr-btn--tool-links" href="{% absolute_url 'simulation' %}">Vérifier mes obligations</a></li>
                             {% endif %}
                         {% endif %}
                     </ul>

--- a/impact/users/templates/users/login.html
+++ b/impact/users/templates/users/login.html
@@ -34,7 +34,7 @@
                     </div>
 
                     <div class="background-light-grey fr-py-4w fr-my-4w" style="text-align: center;">
-                        Pas encore de compte ? <a href="{% url 'users:creation'%}?mtm_campaign=creation-connexion&mtm_kwd=corps-page" class="fr-link">Créez votre compte</a><br>
+                        Pas encore de compte ? <a href="{% url 'users:creation'%}" class="fr-link">Créez votre compte</a><br>
                     </div>
                 </form>
             </div>


### PR DESCRIPTION
les mtm_campaign sont réservés pour tracker les sources externes de trafic (actions bizdev)

Permet de débloquer #563 pour la partie app