### PR TITLE
feat: supprime automatiquement les vieux utilisateurs non confirmés

### DIFF
--- a/cron.json
+++ b/cron.json
@@ -4,6 +4,9 @@
         "command": "0 0 * * * python3 impact/manage.py supprime_utilisateurs_sur_entreprise_test"
       },
       {
+        "command": "0 0 * * * python3 impact/manage.py supprime_utilisateurs_non_confirmes"
+      },
+      {
         "command": "5 0 * * * python3 impact/manage.py sync_metabase"
       },
       {

--- a/impact/users/management/commands/supprime_utilisateurs_non_confirmes.py
+++ b/impact/users/management/commands/supprime_utilisateurs_non_confirmes.py
@@ -1,0 +1,39 @@
+from datetime import date
+
+from dateutil.relativedelta import relativedelta
+from django.core.management.base import BaseCommand
+
+from users.models import User
+
+
+class Command(BaseCommand):
+    help = "Supprime les utilisateurs de plus de 2 mois qui n'ont toujours pas confirmé leur email"
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--check",
+            action="store_true",
+            help="log seulement les utilisateurs sans les supprimer réellement",
+        )
+
+    def handle(self, *args, **options):
+        il_y_a_deux_mois = date.today() + relativedelta(months=-2)
+
+        if utilisateurs_a_supprimer := User.objects.filter(
+            is_email_confirmed=False, created_at__date__lt=il_y_a_deux_mois
+        ):
+            self.stdout.write(
+                "%s utilisateurs à supprimer" % len(utilisateurs_a_supprimer)
+            )
+            for utilisateur in utilisateurs_a_supprimer:
+                if options["check"]:
+                    self.stdout.write("Utilisateur à supprimer %s" % utilisateur.email)
+                else:
+                    utilisateur.delete()
+                    self.stdout.write(
+                        self.style.SUCCESS(
+                            "Utilisateur supprimé %s" % utilisateur.email
+                        )
+                    )
+        else:
+            self.stdout.write("Aucun utilisateur à supprimer")


### PR DESCRIPTION
close #548 

La branche part de la gestion des droits pour ne pas réintroduire de conflit sur des fichiers qui utilisent les vieilles fonctions des habilitations (même si cette PR n'en utilise pas directement)