### PR TITLE
Amélioration des performances de l'admin

### DIFF
--- a/impact/habilitations/admin.py
+++ b/impact/habilitations/admin.py
@@ -29,4 +29,5 @@ class HabilitationInline(admin.TabularInline):
     model = Habilitation
     form = HabilitationAdminForm
     readonly_fields = ("confirmed_at",)
+    raw_id_fields = ("user", "invitation")
     extra = 0


### PR DESCRIPTION
Pour accélerer le chargement des pages d'admin, passage des champs `invitation` et `user` en `raw_id` : on évite le chargement tous les éléments liés lors du rendu de la page.
