### PR TITLE
allongement de la durée de validité de l'invitation

### DIFF
--- a/impact/impact/settings.py
+++ b/impact/impact/settings.py
@@ -239,8 +239,8 @@ LOGOUT_REDIRECT_URL = "/"
 
 # Invitations
 INVITATION_MAX_AGE = int(
-    os.getenv("INVITATION_MAX_AGE", 60 * 60 * 24 * 10)
-)  # en secondes, 10 jours par défaut
+    os.getenv("INVITATION_MAX_AGE", 60 * 60 * 24 * 30)
+)  # en secondes, 30 jours par défaut
 
 # Sentry
 SENTRY_DSN = os.getenv("SENTRY_DSN")


### PR DESCRIPTION
passe de 10 à 30 jours pour donner plus de temps aux utilisateurs d'accepter l'invitation.

close: [#596](https://github.com/betagouv/portail-rse/issues/596)