### PR TITLE
feat: modification de l'entreprise seulement pour les propriétaires

### DIFF
--- a/impact/entreprises/templates/entreprises/index.html
+++ b/impact/entreprises/templates/entreprises/index.html
@@ -78,9 +78,11 @@
                                             <li>
                                                 <a href="{% url 'reglementations:tableau_de_bord' entreprise.siren %}" class="fr-btn fr-btn--icon-left fr-icon-todo-line">Accéder au tableau de bord</a>
                                             </li>
-                                            <li>
-                                                <a href="{% url 'entreprises:qualification' entreprise.siren %}" class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-edit-line">Modifier ces informations</a>
-                                            </li>
+                                            {% if habilitation.role == "proprietaire" %}
+                                                <li>
+                                                    <a href="{% url 'entreprises:qualification' entreprise.siren %}" class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-edit-line">Modifier ces informations</a>
+                                                </li>
+                                            {% endif %}
                                             <li>
                                                 <a href="{% url 'habilitations:membres_entreprise' entreprise.siren %}" class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-team-line">Gérer les membres</a>
                                             </li>

--- a/impact/habilitations/decorators.py
+++ b/impact/habilitations/decorators.py
@@ -10,6 +10,7 @@ def role(*required_roles):
     """
     Décorateur pour vérifier que l'utilisateur a une habilitation pour l'entreprise spécifiée
     et que son rôle satisfait au moins un des rôles requis, en tenant compte de la hiérarchie.
+    Note: l'utilisateur doit être rattaché à une entreprise
     """
 
     def decorateur(view_func):


### PR DESCRIPTION
Tout est dans le titre 😄 

Plus sérieusement : le bouton "Modifier ces informations" dans les liste des entreprises est absent pour les utilisateurs qui ne sont pas propriétaires.