### PR TITLE
fix: limite du nombre de cron pour Scalingo

### DIFF
--- a/cron.json
+++ b/cron.json
@@ -7,13 +7,7 @@
         "command": "0 0 * * * python3 impact/manage.py supprime_utilisateurs_non_confirmes"
       },
       {
-        "command": "5 0 * * * python3 impact/manage.py sync_bges"
-      },
-      {
-        "command": "10 0 * * * python3 impact/manage.py sync_egapro"
-      },
-      {
-        "command": "15 0 * * * python3 impact/manage.py sync_metabase"
+        "command": "5 0 * * * scripts/sync_metabase.sh"
       },
       {
         "command": "0 1 * * * python3 impact/manage.py import_utilisateurs_brevo $BREVO_CONTACTS_LIST_ID"

--- a/scripts/sync_metabase.sh
+++ b/scripts/sync_metabase.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+# Exécute les commandes de gestion Django pour synchroniser les données avec Metabase
+python manage.py sync_egapro
+python manage.py sync_bges
+python manage.py sync_metabase


### PR DESCRIPTION
TIL: limité à 5 commandes max., au delà on doit faire appel au support
