### PR TITLE
feat: ajout de django-hijack

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -26,6 +26,8 @@ filetype = "~=1.2"
 # tables de travail analytics / Metabase
 aiohttp = "~=3.12.15"
 responses = "~=0.25.8"
+# admin : connexion en tant qu'utilisateur enregistré
+django-hijack = "~=3.7.4"
 
 [dev-packages]
 pytest-django = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "2d53a53bfa551f0e3045315173e7600e52593120cef53e3c25d13dab68c197e6"
+            "sha256": "3f3b4ff3409b487a0a695b7dee17810d9ed6160ea4c821b4800ec7cabf4f79e0"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -143,19 +143,19 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:222b44ee4d6e4e8a9a2a4bada4c683c38f37481e545f7997aee7bc40a7fb4489",
-                "sha256:ed64d63cb24721ff603547caf099f3abf82783472910a3650ce8764c78396e7a"
+                "sha256:4b7fbd2b469d5fa6325f0e90310b2d430c9a35e8a984a9919103e6d248422537",
+                "sha256:667bc3a9bd1f26579957d95a2612359103c343dd74d44f202d09a155ed4189c6"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==1.40.10"
+            "version": "==1.40.16"
         },
         "botocore": {
             "hashes": [
-                "sha256:22aff400250a0125be92e0d43011eb42414a64f999d5215827af91d8584b4476",
-                "sha256:db3b14043bc90fe4220edbc2e89e8f5af1d2d4aacc16bab3c30dacd98b0073e3"
+                "sha256:0296a245cb349431279d825522ae70270edf8d8be7b91108fdcc086ea347c0b6",
+                "sha256:522a8b7e3837667aca978b5b2dd2d12c3834f58f13df3c8d3369070d883d608d"
             ],
             "markers": "python_version >= '3.9'",
-            "version": "==1.40.10"
+            "version": "==1.40.16"
         },
         "brotli": {
             "hashes": [
@@ -503,6 +503,15 @@
             ],
             "index": "pypi",
             "version": "==4.0"
+        },
+        "django-hijack": {
+            "hashes": [
+                "sha256:08419f130b9ab95b605b30b1bad30a01412cf58b1ff56c67e51527b25383ea64",
+                "sha256:73ede036db49b13e615994e28e98446345d27400bdc54100be218a20cb3130aa"
+            ],
+            "index": "pypi",
+            "markers": "python_version >= '3.9'",
+            "version": "==3.7.4"
         },
         "django-hosts": {
             "hashes": [
@@ -1211,12 +1220,12 @@
         },
         "requests": {
             "hashes": [
-                "sha256:27babd3cda2a6d50b30443204ee89830707d396671944c998b5975b031ac2b2c",
-                "sha256:27d0316682c8a29834d3264820024b62a36942083d52caf2f14c0591336d3422"
+                "sha256:2462f94637a34fd532264295e186976db0f5d453d1cdd31473c85a6a161affb6",
+                "sha256:dbba0bac56e100853db0ea71b82b4dfd5fe2bf6d3754a8893c3af500cec7d7cf"
             ],
             "index": "pypi",
-            "markers": "python_version >= '3.8'",
-            "version": "==2.32.4"
+            "markers": "python_version >= '3.9'",
+            "version": "==2.32.5"
         },
         "responses": {
             "hashes": [

--- a/impact/impact/settings.py
+++ b/impact/impact/settings.py
@@ -59,6 +59,8 @@ INSTALLED_APPS = [
     "anymail",
     "corsheaders",
     "django_hosts",
+    "hijack",
+    "hijack.contrib.admin",
 ]
 MIDDLEWARE = [
     "corsheaders.middleware.CorsMiddleware",
@@ -77,6 +79,8 @@ MIDDLEWARE = [
     # middlewares touchant à l'utilisation d'HTMX
     "utils.middlewares.HTMXRequestMiddleware",
     "utils.middlewares.HTMXRetargetMiddleware",
+    # admin : hijack
+    "hijack.middleware.HijackUserMiddleware",
 ]
 ROOT_URLCONF = "impact.urls"
 TEMPLATES = [

--- a/impact/impact/urls.py
+++ b/impact/impact/urls.py
@@ -36,6 +36,8 @@ urlpatterns = (
         path("", include("users.urls")),
         path("", include("vsme.urls")),
         path("trigger-error-for-sentry-debug/", trigger_error),
+        # admin : hijack
+        path("hijack/", include("hijack.urls")),
     ]
     + static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
     + static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)

--- a/impact/users/models.py
+++ b/impact/users/models.py
@@ -88,3 +88,11 @@ class User(AbstractBaseUser, TimestampedModel):
     @property
     def uidb64(self):
         return uidb64(self)
+
+    @property
+    def is_superuser(self):
+        # FIXME:
+        # la gestion des super-utilisateurs et droits pour l'admin doit être revue :
+        # - pas d'alias pour ce champ
+        # - ajout de PermissionMixin pour le modèle
+        return self.is_staff


### PR DESCRIPTION
Permet de se connecter en lieu et place d'un utilisateur via l'interface d'admin.

### Note
La gestion des droits du modèle `User` devra être revue pour pouvoir utiliser certaines options de l'admin (utilisation de `PermissionMixin`).
