### PR TITLE
fix: retrait de django-hijack

### DIFF
--- a/impact/impact/admin_urls.py
+++ b/impact/impact/admin_urls.py
@@ -2,16 +2,15 @@ from django.contrib import admin
 from django.http import HttpResponseForbidden
 from django.http import HttpResponseNotFound
 from django.http import HttpResponseServerError
-from django.urls import include
 from django.urls import path
 
 # URLs / chemins pour le site d'admin
 
 urlpatterns = [
     path("", admin.site.urls),
-    # admin : hijack
-    path("hijack/", include("hijack.urls")),
 ]
+
+print("patterns:", urlpatterns)
 
 # La gestion des pages d'erreurs doit être redéfinie pour le nouveau site,
 # sinon il tente d'utiliser les templates et vues par défaut (404.html ...)

--- a/impact/impact/settings.py
+++ b/impact/impact/settings.py
@@ -59,12 +59,11 @@ INSTALLED_APPS = [
     "anymail",
     "corsheaders",
     "django_hosts",
-    "hijack",
-    "hijack.contrib.admin",
 ]
 MIDDLEWARE = [
-    "corsheaders.middleware.CorsMiddleware",
+    # django-hosts : doit être au début
     "django_hosts.middleware.HostsRequestMiddleware",
+    "corsheaders.middleware.CorsMiddleware",
     "django.middleware.security.SecurityMiddleware",
     "whitenoise.middleware.WhiteNoiseMiddleware",
     "django.contrib.sessions.middleware.SessionMiddleware",
@@ -75,12 +74,11 @@ MIDDLEWARE = [
     "utils.middlewares.ExtendUserMiddleware",
     "django.contrib.messages.middleware.MessageMiddleware",
     "django.middleware.clickjacking.XFrameOptionsMiddleware",
-    "django_hosts.middleware.HostsResponseMiddleware",
     # middlewares touchant à l'utilisation d'HTMX
     "utils.middlewares.HTMXRequestMiddleware",
     "utils.middlewares.HTMXRetargetMiddleware",
-    # admin : hijack
-    "hijack.middleware.HijackUserMiddleware",
+    # django-hosts : doit être à la fin
+    "django_hosts.middleware.HostsResponseMiddleware",
 ]
 ROOT_URLCONF = "impact.urls"
 TEMPLATES = [

--- a/impact/impact/urls.py
+++ b/impact/impact/urls.py
@@ -49,4 +49,3 @@ if settings.DEBUG:
     from django.contrib import admin
 
     urlpatterns.append(path("admin", admin.site.urls))
-    urlpatterns.append(path("hijack/", include("hijack.urls")))


### PR DESCRIPTION
Tout est dans le titre :(

`django-hosts` refuse de charger correctement une partie des URLs
nécessaire au fonctionnement de `django-hijack`.

Courte investigation à venir sur la recette, voir si ok.

Sinon : revert complet :(
