### PR TITLE
vsme: remplacement du terme module narratif par module complet

### DIFF
--- a/impact/vsme/templates/etapes/module-complet.html
+++ b/impact/vsme/templates/etapes/module-complet.html
@@ -10,10 +10,10 @@
     <div class="fr-grid-row fr-pb-6w">
       {% include "snippets/menu.html" %}
       <div class="fr-col">
-        <h2>Module narratif</h2>
+        <h2>Module complet</h2>
         <div class="fr-callout">
           <p class="fr-callout__text">
-            Le <b>Module narratif</b> s’adresse aux PME qui doivent répondre à des <b>demandes ESG avancées</b> émanant d’investisseurs, de banques, ou de grands clients.<br> Il complète le module de base avec des <b>données enrichies</b> et des <b>exigences sectorielles ou réglementaires spécifiques</b> (comme celles de la SFDR ou du Pilier 3 bancaire).
+            Le <b>Module complet</b> s’adresse aux PME qui doivent répondre à des <b>demandes ESG avancées</b> émanant d’investisseurs, de banques, ou de grands clients.<br> Il complète le module de base avec des <b>données enrichies</b> et des <b>exigences sectorielles ou réglementaires spécifiques</b> (comme celles de la SFDR ou du Pilier 3 bancaire).
           </p>
           <p class="fr-callout__text">
             Ce module est particulièrement utile pour les entreprises déjà engagées dans une démarche RSE structurée ou soumises à des questionnaires ESG complexes.

--- a/impact/vsme/tests.py
+++ b/impact/vsme/tests.py
@@ -28,7 +28,7 @@ def test_acces_vsme_refuse(client, entreprise_qualifiee, bob):
     assert response.status_code == 403, "Bob ne doit pas pouvoir accéder à cette page"
 
 
-@pytest.mark.parametrize("etape", ["introduction", "module_base", "module_narratif"])
+@pytest.mark.parametrize("etape", ["introduction", "module_base", "module_complet"])
 def test_chargement_templates_des_etapes_vsme(
     etape, client, entreprise_qualifiee, alice
 ):
@@ -54,7 +54,7 @@ def test_etape_vsme_inexistante_retourne_une_404(client, entreprise_qualifiee, a
     assert response.status_code == 404
 
 
-@pytest.mark.parametrize("etape", ["introduction", "module_base", "module_narratif"])
+@pytest.mark.parametrize("etape", ["introduction", "module_base", "module_complet"])
 def test_siren_absent_redirige_vers_celui_de_l_entreprise_courante(
     etape, client, entreprise_factory, alice
 ):
@@ -69,7 +69,7 @@ def test_siren_absent_redirige_vers_celui_de_l_entreprise_courante(
     assert response.redirect_chain == [(redirect_url, 302)]
 
 
-@pytest.mark.parametrize("etape", ["introduction", "module_base", "module_narratif"])
+@pytest.mark.parametrize("etape", ["introduction", "module_base", "module_complet"])
 def test_siren_absent_redirige_vers_l_ajout_d_entreprise_si_pas_d_entreprise(
     etape, client, alice
 ):

--- a/impact/vsme/views.py
+++ b/impact/vsme/views.py
@@ -15,7 +15,7 @@ from entreprises.views import get_current_entreprise
 ETAPES = {
     "introduction": "Introduction",
     "module_base": "Module de base",
-    "module_narratif": "Module narratif",
+    "module_complet": "Module complet",
 }
 
 
@@ -72,8 +72,8 @@ def etape_vsme(request, siren, etape):
             template_name = "etapes/introduction.html"
         case "module_base":
             template_name = "etapes/module-base.html"
-        case "module_narratif":
-            template_name = "etapes/module-narratif.html"
+        case "module_complet":
+            template_name = "etapes/module-complet.html"
 
     context |= {
         "lien": reverse("vsme:etape_vsme", kwargs={"siren": siren, "etape": etape}),


### PR DESCRIPTION
La commission européenne utilise le terme « module complet » donc Portail RSE fait de même.