### PR TITLE
fix: 404 si un code ESRS n'existe pas pour la synthèse

### DIFF
--- a/impact/analyseia/tests/test_export_xlsx.py
+++ b/impact/analyseia/tests/test_export_xlsx.py
@@ -444,6 +444,30 @@ def test_telechargement_des_resultats_IA_par_ESRS_d_une_entreprise_inexistante(
     assert response.status_code == 404
 
 
+def test_telechargement_des_resultats_IA_par_ESRS_d_un_ESRS_inexistant(
+    client,
+    entreprise_factory,
+    alice,
+    csrd,
+):
+    entreprise = entreprise_factory(utilisateur=alice, siren="123456789")
+    client.force_login(alice)
+
+    response = client.get(
+        reverse("analyseia:synthese_resultat_par_ESRS", args=["123456789", "H8"]),
+    )
+
+    assert response.status_code == 404
+
+    response = client.get(
+        reverse(
+            "analyseia:synthese_resultat_par_ESRS", args=["123456789", "H8", csrd.id]
+        ),
+    )
+
+    assert response.status_code == 404
+
+
 def test_telechargement_des_resultats_IA_par_ESRS_redirige_vers_la_connexion_si_non_connecté(
     client,
     entreprise_factory,

--- a/impact/analyseia/views.py
+++ b/impact/analyseia/views.py
@@ -8,6 +8,7 @@ from django.contrib import messages
 from django.contrib.auth.decorators import login_required
 from django.core.exceptions import PermissionDenied
 from django.core.mail import EmailMessage
+from django.http import Http404
 from django.http import HttpResponse
 from django.shortcuts import get_object_or_404
 from django.shortcuts import redirect
@@ -27,6 +28,7 @@ from api import analyse_ia
 from api.exceptions import APIError
 from entreprises.decorators import entreprise_qualifiee_requise
 from habilitations.models import Habilitation
+from reglementations.enums import ESRS
 from reglementations.views import tableau_de_bord_menu_context
 from utils.xlsx import xlsx_response
 
@@ -245,6 +247,9 @@ def synthese_resultat(request, entreprise_qualifiee, csrd_id=None):
 @login_required
 @entreprise_qualifiee_requise
 def synthese_resultat_par_ESRS(request, entreprise_qualifiee, code_esrs, csrd_id=None):
+    if code_esrs not in ESRS.codes():
+        raise Http404
+
     rendu = "esrs" if csrd_id else "theme"
     prefixe_ESRS = rendu == "esrs"
     chemin_xlsx = Path(

--- a/impact/reglementations/enums.py
+++ b/impact/reglementations/enums.py
@@ -22,6 +22,21 @@ class ESRS(models.TextChoices):
 
     ESRS_G1 = "ESRS_G1"
 
+    @classmethod
+    def codes(cls):
+        return (
+            "E1",
+            "E2",
+            "E3",
+            "E4",
+            "E5",
+            "S1",
+            "S2",
+            "S3",
+            "S4",
+            "G1",
+        )
+
 
 class ThemeESRS(Enum):
     ESRS_E1 = "environnement"


### PR DESCRIPTION
Plus de 1000 requêtes en erreur sur Sentry à cause de tentatives hasardeuses d'utilisateurs