### PR TITLE
feat: ajout d'un décorateur pour logger les parcours utilisateurs

### DIFF
--- a/impact/logs/decorators.py
+++ b/impact/logs/decorators.py
@@ -1,0 +1,50 @@
+from functools import wraps
+
+from logs import event_logger as logger
+
+
+def log_path(msg: str):
+    """
+    Décorateur pour logger les parcours utilisateur.
+
+    Args:
+        msg: Message à logger
+
+    Utilisation:
+        @log_path("page:mon_parcours")
+        def ma_vue(request, ...):
+            ...
+
+    Loggue les informations suivantes (si disponibles):
+        - idUtilisateur: PK de l'utilisateur connecté
+        - siren: SIREN de l'entreprise (depuis la session)
+        - session: Identifiant de session
+    """
+
+    def decorator(function):
+        @wraps(function)
+        def wrap(request, *args, **kwargs):
+            payload = {}
+
+            # Récupérer l'ID utilisateur si connecté
+            if hasattr(request, "user") and request.user.is_authenticated:
+                payload |= {"idUtilisateur": request.user.pk}
+
+            # Récupérer le SIREN depuis la session
+            if hasattr(request, "session") and "entreprise" in request.session:
+                payload |= {"siren": request.session["entreprise"]}
+
+            # Récupérer l'identifiant de session
+            if hasattr(request, "session") and request.session.session_key:
+                payload |= {"session": request.session.session_key}
+
+            # Logger le parcours utilisateur (si il ya des données)
+            if payload:
+                logger.info(msg, payload)
+
+            # Exécuter la vue
+            return function(request, *args, **kwargs)
+
+        return wrap
+
+    return decorator


### PR DESCRIPTION
Ajout d'un décorateur `log_path` permettant de tracer les utilisations d'une vue
```python
@log_path("app:tableauDeBord")
func ma_vue(request):
  ...
``` 
Les informations loggées, si disponibles sont : 
- `idUtilisateur` : pk de l'utilisateur
- `siren` : SIREN de l'entreprise en session
- `session` : identifiant de la session, pour permettre de regrouper les données pour un parcours donné
