### PR TITLE
admin: visualisation des logs, non modifiables

### DIFF
--- a/impact/logs/admin.py
+++ b/impact/logs/admin.py
@@ -1,0 +1,15 @@
+from django.contrib import admin
+
+from logs.models import EventLog
+
+
+class EventLogAdmin(admin.ModelAdmin):
+    model = EventLog
+    readonly_fields = (
+        "created_at",
+        "msg",
+        "payload",
+    )
+
+
+admin.site.register(EventLog, EventLogAdmin)


### PR DESCRIPTION
Non modifiable pour éviter de fausser les données, en particulier le JSON