### PR TITLE
fix: changement des années des rapports VSME fonctionnels sur Chrome

### DIFF
--- a/impact/vsme/templates/vsme/categories.html
+++ b/impact/vsme/templates/vsme/categories.html
@@ -22,10 +22,10 @@
                             <label class="fr-label" for="select-annee">
                                 Année du rapport VSME
                             </label>
-                            <select class="fr-select" id="select-annee" name="annee">
+                            <select class="fr-select" id="select-annee" name="annee"
+                                    hx-get="{% url 'vsme:categories_vsme' entreprise.siren %}">
                                 {% for annee in annees_disponibles reversed %}
-                                    <option value="{{ annee }}" {% if annee == rapport_vsme.annee %}selected{% endif %}
-                                            hx-get="{% url 'vsme:categories_vsme' entreprise.siren annee %}">
+                                    <option value="{{ annee }}" {% if annee == rapport_vsme.annee %}selected{% endif %}>
                                         {{ annee }}{% if annee == annee_par_defaut %} (par défaut){% endif %}
                                     </option>
                                 {% endfor %}

--- a/impact/vsme/tests/test_navigation_annees.py
+++ b/impact/vsme/tests/test_navigation_annees.py
@@ -59,6 +59,22 @@ def test_acces_annee_n_plus_1_avec_cloture_30_juin(client, entreprise_factory, a
     ).exists()
 
 
+def test_acces_avec_annee_valide_en_paramètre(client, entreprise_factory, alice):
+    """utile pour le changement d'année en HTMX"""
+    entreprise = entreprise_factory(utilisateur=alice)
+    entreprise.date_cloture_exercice = date(2023, 12, 31)
+    entreprise.save()
+    client.force_login(alice)
+
+    url = reverse("vsme:categories_vsme", args=[entreprise.siren]) + "?annee=2026"
+    response = client.get(url, headers={"HX-Request": "true"}, follow=False)
+
+    assert response.status_code == 200
+    assert response.headers["HX-Redirect"] == reverse(
+        "vsme:categories_vsme", args=[entreprise.siren, 2026]
+    )
+
+
 @pytest.mark.parametrize(
     "annee",
     [

--- a/impact/vsme/views.py
+++ b/impact/vsme/views.py
@@ -118,6 +118,7 @@ def etape_vsme(request, siren, etape):
 @entreprise_qualifiee_requise
 def categories_vsme(request, entreprise_qualifiee, annee=None):
     if htmx.is_htmx(request):
+        annee = request.GET["annee"]
         redirect_to = reverse(
             "vsme:categories_vsme",
             args=[entreprise_qualifiee.siren, annee],


### PR DESCRIPTION
Fonctionnait sur Firefox car un événement est levé lors d'une modification d'un `<option>`. Chrome n'a pas cet événement.
Tous les navigateurs ont un événement sur le `<select>` donc utilisation de cet événement.