### PR TITLE
csrd: indication temporaire concernant la directive Omnibus

### DIFF
--- a/impact/reglementations/templates/reglementations/tableau_de_bord/base.html
+++ b/impact/reglementations/templates/reglementations/tableau_de_bord/base.html
@@ -39,7 +39,7 @@
 
                 <div class="fr-callout fr-icon-info-line">
                     <p class="fr-callout__text">
-                        {{ status.status_detail }}
+                        {{ status.status_detail | safe }}
                     </p>
                 </div>
 

--- a/impact/reglementations/tests/tests_csrd/test_csrd_reglementation.py
+++ b/impact/reglementations/tests/tests_csrd/test_csrd_reglementation.py
@@ -1228,9 +1228,8 @@ def test_calcule_etat_si_soumis_en_2025_et_delegable(entreprise_factory):
     )
 
     assert reglementation.status == ReglementationStatus.STATUS_A_ACTUALISER
-    assert (
-        reglementation.status_detail
-        == "Vous êtes soumis à cette réglementation à partir de 2025 sur les données de l'exercice comptable 2024 car votre société est cotée sur un marché réglementé, l'effectif du groupe est supérieur à 500 salariés, le bilan du groupe est supérieur à 30M€ et le chiffre d'affaires du groupe est supérieur à 60M€. Vous pouvez déléguer cette obligation à votre société-mère. Vous devez publier le Rapport de Durabilité en même temps que le rapport de gestion."
+    assert reglementation.status_detail.startswith(
+        "Vous êtes soumis à cette réglementation à partir de 2025 sur les données de l'exercice comptable 2024 car votre société est cotée sur un marché réglementé, l'effectif du groupe est supérieur à 500 salariés, le bilan du groupe est supérieur à 30M€ et le chiffre d'affaires du groupe est supérieur à 60M€. Vous pouvez déléguer cette obligation à votre société-mère. Vous devez publier le Rapport de Durabilité en même temps que le rapport de gestion."
     )
     assert reglementation.prochaine_echeance == 2025
     assert reglementation.primary_action.title == "Actualiser mon Rapport de Durabilité"
@@ -1260,9 +1259,8 @@ def test_calcule_etat_si_soumis_en_2029_et_non_delegable(entreprise_factory):
 
     assert reglementation.status == ReglementationStatus.STATUS_A_ACTUALISER
 
-    assert (
-        reglementation.status_detail
-        == "Vous êtes soumis à cette réglementation à partir de 2029 sur les données de l'exercice comptable 2028 car votre société est cotée sur un marché réglementé, votre effectif est supérieur à 10 salariés et votre bilan est supérieur à 450k€. Vous devez publier le Rapport de Durabilité en même temps que le rapport de gestion."
+    assert reglementation.status_detail.startswith(
+        "Vous êtes soumis à cette réglementation à partir de 2029 sur les données de l'exercice comptable 2028 car votre société est cotée sur un marché réglementé, votre effectif est supérieur à 10 salariés et votre bilan est supérieur à 450k€. Vous devez publier le Rapport de Durabilité en même temps que le rapport de gestion."
     )
     assert reglementation.prochaine_echeance == 2029
     assert reglementation.primary_action.title == "Actualiser mon Rapport de Durabilité"
@@ -1293,9 +1291,8 @@ def test_calcule_etat_si_entreprise_hors_EEE_soumise_en_2029_sous_condition(
     )
 
     assert reglementation.status == ReglementationStatus.STATUS_A_ACTUALISER
-    assert (
-        reglementation.status_detail
-        == "Vous êtes soumis à cette réglementation à partir de 2029 sur les données de l'exercice comptable 2028 si votre société dont le siège social est hors EEE revêt une forme juridique comparable aux sociétés par actions ou aux sociétés à responsabilité limitée, comptabilise un chiffre d'affaires net dans l'Espace économique européen qui excède 150 millions d'euros à la date de clôture des deux derniers exercices consécutifs, ne contrôle ni n'est contrôlée par une autre société et dispose d'une succursale en France dont le chiffre d'affaires net excède 40 millions d'euros. Vous devez publier le Rapport de Durabilité en même temps que le rapport de gestion."
+    assert reglementation.status_detail.startswith(
+        "Vous êtes soumis à cette réglementation à partir de 2029 sur les données de l'exercice comptable 2028 si votre société dont le siège social est hors EEE revêt une forme juridique comparable aux sociétés par actions ou aux sociétés à responsabilité limitée, comptabilise un chiffre d'affaires net dans l'Espace économique européen qui excède 150 millions d'euros à la date de clôture des deux derniers exercices consécutifs, ne contrôle ni n'est contrôlée par une autre société et dispose d'une succursale en France dont le chiffre d'affaires net excède 40 millions d'euros. Vous devez publier le Rapport de Durabilité en même temps que le rapport de gestion."
     )
     assert reglementation.prochaine_echeance == 2029
 
@@ -2080,7 +2077,7 @@ def test_calcule_etat_si_soumis_en_2026_car_exercice_comptable_different_annee_c
         "Vous êtes soumis à cette réglementation à partir de 2026 sur les données de l'exercice comptable 2024-2025 car"
     )
     assert reglementation.status_detail.endswith(
-        "Vous devez publier le Rapport de Durabilité en même temps que le rapport de gestion."
+        "Vous devez publier le Rapport de Durabilité en même temps que le rapport de gestion.<br>⚠️ À noter : la directive Omnibus I relève les seuils d'assujettissement à 1 000 salariés et 450 M€ de CA. Ces nouveaux seuils ne s'appliqueront qu'après transposition en droit français, attendue au plus tard le 19 mars 2027. Si vous ne dépassez pas ces deux seuils, vous pourriez ne plus être concerné. Cette page sera mise à jour dès la publication du texte français."
     )
     assert reglementation.prochaine_echeance == 2026
 

--- a/impact/reglementations/views/csrd/csrd.py
+++ b/impact/reglementations/views/csrd/csrd.py
@@ -370,6 +370,7 @@ class CSRDReglementation(Reglementation):
                         " Vous pouvez déléguer cette obligation à votre société-mère."
                     )
             status_detail += " Vous devez publier le Rapport de Durabilité en même temps que le rapport de gestion."
+            status_detail += "<br>⚠️ À noter : la directive Omnibus I relève les seuils d'assujettissement à 1 000 salariés et 450 M€ de CA. Ces nouveaux seuils ne s'appliqueront qu'après transposition en droit français, attendue au plus tard le 19 mars 2027. Si vous ne dépassez pas ces deux seuils, vous pourriez ne plus être concerné. Cette page sera mise à jour dès la publication du texte français."
             # notes (FV):
             # AMA, ces aspects sont métiers et devraient êtres rattaché à l'objet métier correspondant
             # c.a.d `RapportCSRD`


### PR DESCRIPTION
pour rendre explicite aux utilisateurs le futur changement de seuil.

Lorsque la directive sera transposée en droit français, il faudra changer les seuils et supprimer cette explication.