### PR TITLE
fix: évite la suppression involontaire de lignes d'un indicateur tableau

### DIFF
--- a/impact/impact/settings.py
+++ b/impact/impact/settings.py
@@ -84,6 +84,7 @@ MIDDLEWARE = [
     # middlewares touchant à l'utilisation d'HTMX
     "utils.middlewares.HTMXRequestMiddleware",
     "utils.middlewares.HTMXRetargetMiddleware",
+    "utils.middlewares.HTMXAuthRedirectMiddleware",
     # django-hosts : doit être à la fin
     "django_hosts.middleware.HostsResponseMiddleware",
 ]

--- a/impact/utils/middlewares.py
+++ b/impact/utils/middlewares.py
@@ -1,7 +1,9 @@
+from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 
-from .htmx import is_htmx
 from users.models import User
+from utils.htmx import HttpResponseHXRedirect
+from utils.htmx import is_htmx
 
 
 class ExtendUserMiddleware:
@@ -72,5 +74,28 @@ class HTMXRequestMiddleware:
         request.htmx = request.headers.get("HX-Request") == "true"
 
         response = self.get_response(request)
+
+        return response
+
+
+class HTMXAuthRedirectMiddleware:
+    """
+    Convertit une redirection HTTP vers la page de connexion en réponse `HX-Redirect`
+    lorsque la requête est HTMX, pour éviter d'injecter la page de connexion
+    dans la cible HTMX (typiquement une modale).
+    """
+
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+
+        if (
+            is_htmx(request)
+            and response.status_code == 302
+            and response.url.startswith(settings.LOGIN_URL)
+        ):
+            return HttpResponseHXRedirect(response.url)
 
         return response

--- a/impact/vsme/templates/fragments/indicateur.html
+++ b/impact/vsme/templates/fragments/indicateur.html
@@ -112,7 +112,15 @@
                                                     {% if form.indicator_type == "table" %}
                                                         <!-- Bouton de suppression de ligne -->
                                                         <td class="indicateur-cellule">
-                                                            <button type="submit" name="supprimer-ligne" value="{{ form_table.DELETE.html_name }}" class="fr-btn fr-icon-delete-line fr-btn--tertiary-no-outline" title="Supprimer" {% if not indicateur_est_applicable or multiform.non_pertinent %}disabled{% endif %}>Supprimer</button>
+                                                            <button type="button"
+                                                                    hx-post="{% url 'vsme:indicateur_vsme' rapport_vsme.id indicateur_schema_id %}"
+                                                                    hx-vals='{"supprimer-ligne": "{{ form_table.DELETE.html_name }}"}'
+                                                                    hx-confirm="Êtes-vous sûr de vouloir supprimer cette ligne ?"
+                                                                    class="fr-btn fr-icon-delete-line fr-btn--tertiary-no-outline"
+                                                                    title="Supprimer"
+                                                                    {% if not indicateur_est_applicable or multiform.non_pertinent %}disabled{% endif %}>
+                                                                Supprimer
+                                                            </button>
                                                         </td>
                                                     {% endif %}
                                                 </tr>
@@ -131,7 +139,14 @@
                                 {% endif %}
                                 {% if form.indicator_type == "table" %}
                                     <!-- Bouton d'ajout de ligne -->
-                                    <button type="submit" name="ajouter-ligne" value="{{ form.id }}" class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-add-circle-line fr-mb-2w" {% if not indicateur_est_applicable or multiform.non_pertinent %}disabled{% endif %}>Ajouter une ligne</button>
+                                    <button type="button"
+                                            hx-post="{% url 'vsme:indicateur_vsme' rapport_vsme.id indicateur_schema_id %}"
+                                            hx-vals='{"ajouter-ligne": "{{ form.id }}"}'
+                                            class="fr-btn fr-btn--secondary fr-btn--icon-left fr-icon-add-circle-line fr-mb-2w"
+                                            title="Supprimer"
+                                            {% if not indicateur_est_applicable or multiform.non_pertinent %}disabled{% endif %}>
+                                        Ajouter une ligne
+                                    </button>
                                 {% endif %}
                                 <div class="fr-mb-2w"></div>
                             {% else %}

--- a/impact/vsme/tests/test_donnees_calculees.py
+++ b/impact/vsme/tests/test_donnees_calculees.py
@@ -16,7 +16,11 @@ def test_indicateur_calculé_affiche_les_donnees_calculées(client, alice, rappo
         INDICATEURS_VSME_BASE_URL
         + f"{rapport_vsme.id}/indicateur/{indicateur_conventions_collectives}/"
     )
-    response = client.post(url, {"nombre_salaries_conventions_collectives": 10})
+    response = client.post(
+        url,
+        {"nombre_salaries_conventions_collectives": 10},
+        headers={"HX-Request": "true"},
+    )
 
     assert response.status_code == 200
     context = response.context
@@ -36,7 +40,11 @@ def test_indicateur_calculé_affiche_na_si_incalculable(client, alice, rapport_v
         INDICATEURS_VSME_BASE_URL
         + f"{rapport_vsme.id}/indicateur/{indicateur_conventions_collectives}/"
     )
-    response = client.post(url, {"nombre_salaries_conventions_collectives": 10})
+    response = client.post(
+        url,
+        {"nombre_salaries_conventions_collectives": 10},
+        headers={"HX-Request": "true"},
+    )
 
     assert response.status_code == 200
     context = response.context

--- a/impact/vsme/tests/test_indicateur.py
+++ b/impact/vsme/tests/test_indicateur.py
@@ -70,3 +70,13 @@ def test_indicateur_vsme_est_prive(client, bob, rapport_vsme):
     response = client.get(url)
 
     assert response.status_code == 403
+
+
+def test_indicateur_vsme_htmx_non_authentifie_renvoie_hx_redirect(client, rapport_vsme):
+    """Évite d'injecter la page de connexion dans la modale et de casser l'affichage"""
+    url = INDICATEUR_VSME_URL.format(vsme_id=rapport_vsme.id)
+    response = client.get(url, headers={"HX-Request": "true"})
+
+    connexion_url = reverse("users:login")
+    assert response.status_code == 200
+    assert response["HX-Redirect"] == f"{connexion_url}?next={url}"

--- a/impact/vsme/tests/test_indicateur.py
+++ b/impact/vsme/tests/test_indicateur.py
@@ -7,14 +7,30 @@ from vsme.tests.test_indicateurs import INDICATEURS_VSME_BASE_URL
 INDICATEUR_VSME_URL = INDICATEURS_VSME_BASE_URL + "{vsme_id}/indicateur/B1-24-a/"
 
 
-def test_indicateur_vsme_avec_utilisateur_authentifie(client, alice, rapport_vsme):
+def test_indicateur_vsme_htmx_renvoie_le_fragment(client, alice, rapport_vsme):
+    client.force_login(alice)
+
+    url = INDICATEUR_VSME_URL.format(vsme_id=rapport_vsme.id)
+    response = client.get(url, headers={"HX-Request": "true"})
+
+    assert response.status_code == 200
+    assertTemplateUsed(response, "fragments/indicateur.html")
+
+
+def test_indicateur_vsme_non_htmx_redirige_vers_l_exigence(client, alice, rapport_vsme):
     client.force_login(alice)
 
     url = INDICATEUR_VSME_URL.format(vsme_id=rapport_vsme.id)
     response = client.get(url)
 
-    assert response.status_code == 200
-    assertTemplateUsed(response, f"fragments/indicateur.html")
+    assert response.status_code == 302
+    assert response.url == reverse(
+        "vsme:exigence_de_publication_vsme",
+        kwargs={
+            "vsme_id": rapport_vsme.id,
+            "exigence_de_publication_code": "B1",
+        },
+    )
 
 
 @pytest.mark.parametrize("indicateur_schema_id", ["ZZZ", "B1-ZZZ"])

--- a/impact/vsme/tests/test_preremplissage.py
+++ b/impact/vsme/tests/test_preremplissage.py
@@ -50,7 +50,7 @@ def test_indicateur_prerempli_affiche_le_preremplissage(client, alice, rapport_v
     client.force_login(alice)
 
     url = INDICATEURS_VSME_BASE_URL + f"{rapport_vsme.id}/indicateur/B1-24-e-i/"
-    response = client.get(url)
+    response = client.get(url, headers={"HX-Request": "true"})
 
     assert response.status_code == 200
     context = response.context
@@ -71,7 +71,7 @@ def test_indicateur_deja_complete_n_affiche_pas_le_preremplissage(
     client.force_login(alice)
 
     url = INDICATEURS_VSME_BASE_URL + f"{rapport_vsme.id}/indicateur/B1-24-e-i/"
-    response = client.get(url)
+    response = client.get(url, headers={"HX-Request": "true"})
 
     assert response.status_code == 200
     context = response.context

--- a/impact/vsme/views.py
+++ b/impact/vsme/views.py
@@ -194,6 +194,14 @@ def indicateur_vsme(request, rapport_vsme, indicateur_schema_id):
     exigence_de_publication = ExigenceDePublication.par_indicateur_schema_id(
         indicateur_schema_id
     )
+    exigence_de_publication_url = reverse(
+        "vsme:exigence_de_publication_vsme",
+        args=[rapport_vsme.id, exigence_de_publication.code],
+    )
+
+    if not htmx.is_htmx(request):
+        return redirect(exigence_de_publication_url)
+
     indicateur_est_applicable, explication_non_applicable = (
         rapport_vsme.indicateur_est_applicable(indicateur_schema_id)
     )
@@ -232,12 +240,7 @@ def indicateur_vsme(request, rapport_vsme, indicateur_schema_id):
                     request,
                     f"L'indicateur « {indicateur_schema["titre"]} » a bien été enregistré.",
                 )
-                redirect_to = reverse(
-                    "vsme:exigence_de_publication_vsme",
-                    args=[rapport_vsme.id, exigence_de_publication.code],
-                )
-                if htmx.is_htmx(request):
-                    return htmx.HttpResponseHXRedirect(redirect_to)
+                return htmx.HttpResponseHXRedirect(exigence_de_publication_url)
         elif "ajouter-ligne" in request.POST:
             if multiform.is_valid():
                 data = ajoute_donnes_calculees(

--- a/impact/vsme/views.py
+++ b/impact/vsme/views.py
@@ -228,6 +228,10 @@ def indicateur_vsme(request, rapport_vsme, indicateur_schema_id):
                         data=multiform.cleaned_data,
                     )
                 indicateur.save()
+                messages.success(
+                    request,
+                    f"L'indicateur « {indicateur_schema["titre"]} » a bien été enregistré.",
+                )
                 redirect_to = reverse(
                     "vsme:exigence_de_publication_vsme",
                     args=[rapport_vsme.id, exigence_de_publication.code],


### PR DESCRIPTION
évite la suppression involontaire de lignes lorsqu'un utilisateur appuie sur la touche entrée après avoir sélectionné un champ du tableau

L'appui sur entrée après avoir sélectionné un champ de formulaire html provoque le déclenchement du premier bouton de type submit du formulaire. Le bouton de suppression de ligne étant le premier, c'était celui-ci qui était déclenché. Cela était particulièrement invisible pour l'utilisateur qui avait saisi beaucoup de lignes car la requête htmx est silencieuse et raffiche le formulaire avec la ligne supprimée. Si l'utilisateur ne s'en rendait pas compte et cliquait ensuite sur le bouton Enregistrer, il perdait les données des lignes qui avaient été supprimées via ce comportement silencieux involontaire. Cela est arrivé en prod plusieurs fois, en particulier sur l'indicateur Liste des sites.

close #968 