### PR TITLE
feat: ajoute l'attribut brevo EXT_ID dans l'import quotidien des utilisateurs sur brevo

### DIFF
--- a/impact/users/management/commands/import_utilisateurs_brevo.py
+++ b/impact/users/management/commands/import_utilisateurs_brevo.py
@@ -15,11 +15,25 @@ def _client_api():
 
 
 class Command(BaseCommand):
+    help = "Importe les utilisateurs dans Brevo"
+
     def add_arguments(self, parser):
-        parser.add_argument("list_id", type=int)
+        parser.add_argument(
+            "list_id",
+            nargs="?",
+            type=int,
+            help="ID de la liste de contacts Brevo dans laquelle les utilisateurs seront importés. Si aucun ID n'est fourni, la commande ne fait rien.",
+        )
 
     def handle(self, *args, **options):
         list_id = options["list_id"]
+        if list_id is None:
+            self.stdout.write(
+                self.style.SUCCESS(
+                    "Aucun ID de liste de contacts fourni. Import des utilisateurs dans Brevo annulé."
+                )
+            )
+            return
         client_api = _client_api()
         api_instance = ContactsApi(client_api)
         request_contact_import = RequestContactImport()
@@ -47,3 +61,6 @@ class Command(BaseCommand):
         request_contact_import.update_existing_contacts = True
         request_contact_import.empty_contacts_attributes = True
         api_instance.import_contacts(request_contact_import)
+        self.stdout.write(
+            self.style.SUCCESS("Import des utilisateurs dans Brevo teminé.")
+        )

--- a/impact/users/management/commands/import_utilisateurs_brevo.py
+++ b/impact/users/management/commands/import_utilisateurs_brevo.py
@@ -27,6 +27,7 @@ class Command(BaseCommand):
             {
                 "email": user.email,
                 "attributes": {
+                    "EXT_ID": user.id,
                     "PORTAIL_RSE_ID": user.id,
                     "PORTAIL_RSE_DATE_INSCRIPTION": f"{user.created_at:%d-%m-%Y}",
                     "EMAIL_CONFIRME": "yes" if user.is_email_confirmed else None,

--- a/impact/users/tests/test_commands.py
+++ b/impact/users/tests/test_commands.py
@@ -55,6 +55,17 @@ def test_import_des_contacts(
     assert request_contact_import.empty_contacts_attributes == True
 
 
+def test_import_des_contacts_annulé_si_list_id_absent(mocker, settings):
+    settings.BREVO_API_KEY = "BREVO_API_KEY"
+    mocked_import_contacts = mocker.patch(
+        "sib_api_v3_sdk.ContactsApi.import_contacts",
+    )
+
+    call_command("import_utilisateurs_brevo")
+
+    assert not mocked_import_contacts.called
+
+
 @pytest.mark.django_db(transaction=True)
 def test_supprime_utilisateurs_non_confirmes(django_user_model):
     il_y_a_deux_mois = date.today() + relativedelta(months=-2)

--- a/impact/users/tests/test_commands.py
+++ b/impact/users/tests/test_commands.py
@@ -41,6 +41,7 @@ def test_import_des_contacts(
         {
             "email": alice.email,
             "attributes": {
+                "EXT_ID": alice.id,
                 "PORTAIL_RSE_ID": alice.id,
                 "PORTAIL_RSE_DATE_INSCRIPTION": alice.created_at.strftime("%d-%m-%Y"),
                 "EMAIL_CONFIRME": "yes",


### PR DESCRIPTION
Cet attribut géré nativement par brevo est une des rares clés permise pour réaliser des imports de contacts et la réconciliation avec les contacts existants dans brevo sans avoir besoin de l'email.

En lui assignant la valeur de l'id utilisateur dans le portail RSE, cela permet l'export depuis metabase (qui ne contient pas les emails mais bien les id) et leur ré-import dans une liste brevo pour réaliser des campagnes ciblées.

Ne supprime pas l'attribut pré-existant PORTAIL_RSE_ID pour ne pas casser des éventuels filtres/segments/process actuels dans brevo.

Stoppe l'import des utilisateurs sur la recette pour éviter des conflits sur cet attribut en gérant le cas où aucun id de liste de contacts n'est fourni et en supprimant la variable d'environnement BREVO_CONTACTS_LIST_ID utilisée par le cron d'import.