### PR TITLE
fix: correction de l'export pptx lorsque la donnée d'un tableau à ligne fixe est vide

### DIFF
--- a/impact/vsme/export_pptx.py
+++ b/impact/vsme/export_pptx.py
@@ -281,6 +281,8 @@ def _export_tableau(champ, data, shape):
     _formate_hauteur_tableau(data, table)
 
     for index_ligne, ligne in enumerate(data, start=1):
+        if not ligne:
+            continue
         for index_colonne, schema_colonne in enumerate(champ["colonnes"]):
             data_cellule = ligne[schema_colonne["id"]]
             cell = table.cell(index_ligne, index_colonne)

--- a/impact/vsme/export_pptx.py
+++ b/impact/vsme/export_pptx.py
@@ -216,11 +216,11 @@ def _export_champ_multidiapos(champ, data, export_pptx, presentation):
                 continue
             ligne_id = label_to_id[label]
             data_ligne = data[ligne_id]
-            for col_index, colonne in enumerate(colonnes):
-                data_cellule = data_ligne.get(colonne["id"])
-                cell = table.cell(row_index, col_index + 1)
-                cell.text = formate_valeur(data_cellule, colonne)
-                _applique_style_cellule(cell, data_cellule, colonne)
+            for index_colonne, schema_colonne in enumerate(colonnes):
+                data_cellule = data_ligne.get(schema_colonne["id"])
+                cell = table.cell(row_index, index_colonne + 1)
+                cell.text = formate_valeur(data_cellule, schema_colonne)
+                _applique_style_cellule(cell, data_cellule, schema_colonne)
 
 
 def _export_champ_monodiapo(champ, data, export_pptx, presentation):
@@ -328,15 +328,15 @@ def _export_tableau_lignes_fixes(champ, data, shape):
             for offset_ligne, (code_pays, data_ligne) in enumerate(data.items()):
                 cell = table.cell(offset_ligne + 1, 0)
                 cell.text = CODES_PAYS_ISO_3166_1[code_pays]
-                colonne = colonnes[0]
-                data_cellule = data_ligne.get(colonne["id"])
-                _applique_style_cellule(cell, data_cellule, colonne)
+                schema_colonne = colonnes[0]
+                data_cellule = data_ligne.get(schema_colonne["id"])
+                _applique_style_cellule(cell, data_cellule, schema_colonne)
 
-                for offset_colonne, colonne in enumerate(colonnes):
-                    data_cellule = data_ligne.get(colonne["id"])
+                for offset_colonne, schema_colonne in enumerate(colonnes):
+                    data_cellule = data_ligne.get(schema_colonne["id"])
                     cell = table.cell(offset_ligne + 1, offset_colonne + 1)
-                    cell.text = formate_valeur(data_cellule, colonne)
-                    _applique_style_cellule(cell, data_cellule, colonne)
+                    cell.text = formate_valeur(data_cellule, schema_colonne)
+                    _applique_style_cellule(cell, data_cellule, schema_colonne)
         case "RISQUES_CLIMATIQUES":
             table = shape.table
             _formate_hauteur_tableau(data, table)
@@ -345,11 +345,11 @@ def _export_tableau_lignes_fixes(champ, data, shape):
                 cell.text = formate_valeur(id_risque, {"type": "auto_id"})
                 _applique_style_cellule(cell, id_risque, {"type": "auto_id"})
 
-                for offset_colonne, colonne in enumerate(colonnes):
-                    data_cellule = data_ligne.get(colonne["id"])
+                for offset_colonne, schema_colonne in enumerate(colonnes):
+                    data_cellule = data_ligne.get(schema_colonne["id"])
                     cell = table.cell(offset_ligne + 1, offset_colonne + 1)
-                    cell.text = formate_valeur(data_cellule, colonne)
-                    _applique_style_cellule(cell, data_cellule, colonne)
+                    cell.text = formate_valeur(data_cellule, schema_colonne)
+                    _applique_style_cellule(cell, data_cellule, schema_colonne)
         case "THEMATIQUES_DURABILITE" | list():
             colonnes_ids = [colonne["id"] for colonne in colonnes]
             if lignes == "THEMATIQUES_DURABILITE":

--- a/impact/vsme/tests/test_export_pptx.py
+++ b/impact/vsme/tests/test_export_pptx.py
@@ -238,6 +238,7 @@ def test_export_pptx_d_un_champ_tableau(entreprise_factory, alice):
                     "pays": "FRA",
                     "geolocalisation": "[3,4]",
                 },
+                {},  # il existe des cas en BdD avec un champ vide à la fin
             ]
         },
     )


### PR DESCRIPTION
Il existe au moins un cas où la dernière ligne d'un tableau à lignes variables est vide:

```
data = [
    {
        commentaire: "",
        date_obtention: "2023-09-11",
        emetteur: "EMETTEUR",
        nom_certification: "NOM",
        score: ""
    },
    {}
]
```

Le dictionnaire vide levait une exception `KeyError`. Maintenant, on ignore ces lignes vides.