### PR TITLE
vsme: pptx: pas d'erreur si un schéma a été supprimé

### DIFF
--- a/impact/vsme/export_pptx.py
+++ b/impact/vsme/export_pptx.py
@@ -108,7 +108,7 @@ def selectionne_diapos_non_applicables(rapport_vsme):
     tous_les_indicateur_schema_ids = [
         schema_id
         for exigence in EXIGENCES_DE_PUBLICATION.values()
-        for schema_id in exigence.indicateurs()
+        for schema_id in exigence.indicateur_schema_ids()
     ]
 
     for indicateur_schema_id in tous_les_indicateur_schema_ids:

--- a/impact/vsme/export_pptx.py
+++ b/impact/vsme/export_pptx.py
@@ -15,10 +15,15 @@ from vsme.export_xlsx import formate_valeur as formate_valeur_xlsx
 from vsme.forms import THEMATIQUES_DURABILITE
 from vsme.models import ExigenceDePublication
 from vsme.models import EXIGENCES_DE_PUBLICATION
+from vsme.models import schema_existe
 
 
 def export_rapport_vsme(rapport_vsme, presentation):
-    indicateurs = rapport_vsme.indicateurs.all()
+    indicateurs = [
+        indicateur
+        for indicateur in rapport_vsme.indicateurs.all()
+        if schema_existe(indicateur.schema_id)
+    ]
     export_couverture(rapport_vsme, presentation)
     export_sommaire(rapport_vsme, presentation)
     export_indicateurs(indicateurs, presentation)

--- a/impact/vsme/export_xlsx.py
+++ b/impact/vsme/export_xlsx.py
@@ -12,7 +12,7 @@ from vsme.models import EXIGENCES_DE_PUBLICATION
 def export_exigence_de_publication(
     exigence_de_publication, workbook, indicateurs_par_schema_id
 ):
-    schema_ids = exigence_de_publication.indicateurs()
+    schema_ids = exigence_de_publication.indicateur_schema_ids()
     for indicateur_schema_id in schema_ids:
         try:
             indicateur = indicateurs_par_schema_id[indicateur_schema_id]

--- a/impact/vsme/models.py
+++ b/impact/vsme/models.py
@@ -48,6 +48,16 @@ def validate_annee_rapport(value):
         )
 
 
+def schema_existe(schema_id):
+    """Un schéma peut disparaitre.
+
+    Dans ce cas, les données enregistrées ne correspondent plus à rien."""
+    for exigence in EXIGENCES_DE_PUBLICATION.values():
+        if schema_id in exigence.indicateurs():
+            return True
+    return False
+
+
 class Categorie(Enum):
     GENERAL = {"id": "informations-generales", "label": "Informations générales"}
     ENVIRONNEMENT = {"id": "environnement", "label": "Environnement"}

--- a/impact/vsme/models.py
+++ b/impact/vsme/models.py
@@ -53,7 +53,7 @@ def schema_existe(schema_id):
 
     Dans ce cas, les données enregistrées ne correspondent plus à rien."""
     for exigence in EXIGENCES_DE_PUBLICATION.values():
-        if schema_id in exigence.indicateurs():
+        if schema_id in exigence.indicateur_schema_ids():
             return True
     return False
 
@@ -102,7 +102,7 @@ class ExigenceDePublication:
         code = indicateur_schema_id.split("-")[0]
         return cls.par_code(code)
 
-    def indicateurs(self):
+    def indicateur_schema_ids(self):
         return self.load_json_schema().keys()
 
 
@@ -273,7 +273,7 @@ class RapportVSME(TimestampedModel):
     def indicateurs_applicables(self):
         indicateurs_applicables = []
         for exigence_de_publication in self.exigences_de_publication_applicables():
-            for indicateur_schema_id in exigence_de_publication.indicateurs():
+            for indicateur_schema_id in exigence_de_publication.indicateur_schema_ids():
                 if self.indicateur_est_applicable(indicateur_schema_id)[0]:
                     indicateurs_applicables.append(indicateur_schema_id)
         return indicateurs_applicables
@@ -426,11 +426,11 @@ class RapportVSME(TimestampedModel):
         return self.indicateurs.values_list("schema_id", flat=True)
 
     def progression_par_exigence(self, exigence_de_publication):
-        indicateurs_exigences = set(exigence_de_publication.indicateurs())
-        indicateurs_applicables = indicateurs_exigences.intersection(
+        indicateur_schema_ids = set(exigence_de_publication.indicateur_schema_ids())
+        indicateurs_applicables = indicateur_schema_ids.intersection(
             set(self.indicateurs_applicables)
         )
-        indicateurs_completes = indicateurs_exigences.intersection(
+        indicateurs_completes = indicateur_schema_ids.intersection(
             set(self.indicateurs_completes)
         )
         indicateurs_completes_et_applicables = indicateurs_applicables.intersection(

--- a/impact/vsme/tests/test_export_pptx.py
+++ b/impact/vsme/tests/test_export_pptx.py
@@ -10,6 +10,7 @@ from pptx.util import Pt
 
 from utils.pptx import find_slide
 from vsme.export_pptx import export_indicateurs
+from vsme.export_pptx import export_rapport_vsme
 from vsme.export_pptx import export_sommaire
 from vsme.export_pptx import find_shape
 from vsme.export_pptx import formate_valeur
@@ -58,6 +59,26 @@ def test_telechargement_d_un_rapport_vsme_au_format_pptx(
         response["content-type"]
         == "application/vnd.openxmlformats-officedocument.presentationml.presentation"
     )
+
+
+def test_telechargement_d_un_rapport_vsme_au_format_pptx_fonctionne_avec_anciens_indicateurs_en_base(
+    entreprise_factory, alice
+):
+    """certains indicateurs ont disparu et ne doive pas empècher l'export du pptx"""
+    entreprise = entreprise_factory(utilisateur=alice)
+    rapport_vsme = RapportVSME.objects.create(entreprise=entreprise, annee=2026)
+    indicateur = Indicateur(
+        rapport_vsme=rapport_vsme,
+        schema_id="B99-99",  # ce module n'existe pas dans les schémaa JSON
+        data={"ancienne_donnee": "ne sert plus"},
+    )
+    indicateur.save()
+    chemin_pptx = Path(settings.BASE_DIR, "vsme/exports/vsme.pptx")
+    presentation = Presentation(chemin_pptx)
+
+    export_rapport_vsme(rapport_vsme, presentation)
+
+    # réussite car ne lève pas d'exception KeyError
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Cas d'anciens schémas supprimés.

Il n'est pas possible de se limiter aux indicateurs applicables car il faut gérer les cas d'indicateurs non applicables dans l'export.