### PR TITLE
maj: nodejs à la même version dans package.json et l'intégration cont…

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 16.x
+          node-version: 24.x
       - name: Install front dependencies
         run: npm ci --ignore-scripts
       - name: Build front

--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "private": true,
   "version": "0.0.0",
   "type": "module",
+  "engines": {
+    "node": "24"
+  },
   "scripts": {
     "compile:css": "sass impact/static/scss:impact/static/css",
     "compile:css:watch": "sass impact/static/scss:impact/static/css --watch",


### PR DESCRIPTION
…inue

scalingo précise le moyen d'indiquer la version de node sur https://doc.scalingo.com/languages/nodejs/start#specifying-a-nodejs-version

Il semble que cette définition soit devenue obligatoire.