### PR TITLE
docs: badge sur les tests sous le titre

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-[![test](https://github.com/betagouv/portail-rse/actions/workflows/test.yml/badge.svg)](https://github.com/betagouv/portail-rse/actions/workflows/test.yml)
-
 # Portail RSE
+
+[![test](https://github.com/betagouv/portail-rse/actions/workflows/test.yml/badge.svg)](https://github.com/betagouv/portail-rse/actions/workflows/test.yml)
 
 ## Liens utiles
 


### PR DESCRIPTION
Permet de redéployer avec `scalingo-26(Scalingo Stack based on Ubuntu 26.04 LTS)` à la place de la 22.

[doc Scalingo](https://doc.scalingo.com/platform/internals/stacks/stacks)